### PR TITLE
Move map to pll param when no ll param found

### DIFF
--- a/code/location.js
+++ b/code/location.js
@@ -36,6 +36,14 @@ window.getPosition = function() {
     return {center: new L.LatLng(lat, lng), zoom: z};
   }
 
+  if(getURLParam('pll')) {
+    console.log("mappos: reading stock Intel URL portal params");
+    var lat = parseFloat(getURLParam('pll').split(",")[0]) || 0.0;
+    var lng = parseFloat(getURLParam('pll').split(",")[1]) || 0.0;
+    var z = parseInt(getURLParam('z')) || 17;
+    return {center: new L.LatLng(lat, lng), zoom: z};
+  }
+
   if(readCookie('ingress.intelmap.lat') && readCookie('ingress.intelmap.lng')) {
     console.log("mappos: reading cookies");
     var lat = parseFloat(readCookie('ingress.intelmap.lat')) || 0.0;


### PR DESCRIPTION
If an intel url is opened with a pll parameter but no ll parameter we probably want to center the map on the pll parameter so the portal in in view.  Ran accross this issue with some people shortening intel links to drop the ll parameter, which used to work at one point or another, likely because the stock site parsed it and updated the cookie we use.