### PR TITLE
Removes unwanted characters from passcode

### DIFF
--- a/code/redeeming.js
+++ b/code/redeeming.js
@@ -168,6 +168,7 @@ window.setupRedeem = function() {
     if((e.keyCode ? e.keyCode : e.which) !== 13) return;
 
     var passcode = $(this).val();
+    passcode = passcode.replace(/[^\x20-\x7E]+/g, ''); //removes non-printable characters
     if(!passcode) return;
 
     var jqXHR = window.postAjax('redeemReward', {passcode:passcode}, window.handleRedeemResponse, function(response) {


### PR DESCRIPTION
Sometimes copying passcodes from https://plus.google.com/communities/108599095839806789745 will contain an invisible character(s) at the end which causes it to be invalid. This patch will remove non printable characters from a passcode before submitting it to Ingress.

I've found the bytes 0xefbbbf sometimes appear which is a BOM character.