### PR TITLE
DrawTools: send the layerGroup when running edit and delete hooks

### DIFF
--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -667,12 +667,12 @@ window.plugin.drawTools.boot = function() {
 
   map.on('draw:deleted', function(e) {
     window.plugin.drawTools.save();
-    runHooks('pluginDrawTools',{event:'layersDeleted'});
+    runHooks('pluginDrawTools',{event:'layersDeleted',layers:e.layers});
   });
 
   map.on('draw:edited', function(e) {
     window.plugin.drawTools.save();
-    runHooks('pluginDrawTools',{event:'layersEdited'});
+    runHooks('pluginDrawTools',{event:'layersEdited',layers:e.layers});
   });
   //add options menu
   $('#toolbox').append('<a onclick="window.plugin.drawTools.manualOpt();return false;" accesskey="x" title="[x]">DrawTools Opt</a>');


### PR DESCRIPTION
Much as the draw:created event includes the created layer, the draw:deleted and draw:edited events includes a layerGroup of the affected layers.

This just passes that layerGroup along in the pluginDrawTools hooks for layersDeleted and layersEdited for hook consumers to use.
