### PR TITLE
Change visited neutral portal fill when uniques are highlighted

### DIFF
--- a/plugins/uniques.user.js
+++ b/plugins/uniques.user.js
@@ -391,6 +391,9 @@ window.plugin.uniques.highlighter = {
 		if (uniqueInfo) {
 			if (uniqueInfo.captured) {
 				// captured (and, implied, visited too) - no highlights
+				if (data.portal.options.team === 0){
+                                        style.fillColor = 'lightgrey';
+                                }
 
 			} else if (uniqueInfo.visited) {
 				style.fillColor = 'yellow';


### PR DESCRIPTION
The orange fill on neutral portals is too close to the red fill for non-visited portals. The change I am proposing sets the fill of visited neutral portals to light grey. This creates a clear contrast.