### PR TITLE
togeojson.js: Fix bug with parsing google KML files"

### DIFF
--- a/external/togeojson.js
+++ b/external/togeojson.js
@@ -96,6 +96,8 @@ toGeoJSON = (function() {
                         for (j = 0; j < geomNodes.length; j++) {
                             geomNode = geomNodes[j];
                             if (geotypes[i] == 'Point') {
+                                if(nodeVal(get1(geomNode, 'coordinates')) === null)
+                                    continue;
                                 geoms.push({
                                     type: 'Point',
                                     coordinates: coord1(nodeVal(get1(geomNode, 'coordinates')))


### PR DESCRIPTION
KML overlay plugin fails to load KML files exported from Google Location History.
I found the reason - it's node without value
`<Point><coordinates></coordinates></Point>`
that appears in many Placemark xml nodes. This simple fix allows to load such files without error.
