### PR TITLE
Load OpenStreetMap tiles over https

### DIFF
--- a/plugins/basemap-openstreetmap.user.js
+++ b/plugins/basemap-openstreetmap.user.js
@@ -36,8 +36,8 @@ window.plugin.mapTileOpenStreetMap = {
     };
 
     var layers = {
-      'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png': 'OpenStreetMap',
-      'http://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png': 'Humanitarian',
+      'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png': 'OpenStreetMap',
+      'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png': 'Humanitarian',
     };
 
     for(var url in layers) {


### PR DESCRIPTION
With the Ingress Intel map loaded over HTTPS the OpenStreetMap tiles currently are still loaded over HTTP. This is bad practice and causes a 'Mixed Content' warning in browsers such as Chrome or Firefox.