### PR TITLE
Shows larger color selector on drawtool options

### DIFF
--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -92,11 +92,11 @@ window.plugin.drawTools.setOptions = function() {
 window.plugin.drawTools.setDrawColor = function(color) {
   window.plugin.drawTools.currentColor = color;
   window.plugin.drawTools.currentMarker = window.plugin.drawTools.getMarkerIcon(color);
-  
+
   window.plugin.drawTools.lineOptions.color = color;
   window.plugin.drawTools.polygonOptions.color = color;
   window.plugin.drawTools.markerOptions.icon = window.plugin.drawTools.currentMarker;
-  
+
   plugin.drawTools.drawControl.setDrawingOptions({
     polygon:  { shapeOptions: plugin.drawTools.polygonOptions },
     polyline: { shapeOptions: plugin.drawTools.lineOptions },
@@ -353,6 +353,7 @@ window.plugin.drawTools.manualOpt = function() {
     showInput: false,
     showButtons: false,
     showPalette: true,
+    showPaletteOnly: false,
     showSelectionPalette: false,
     palette: [ ['#a24ac3','#514ac3','#4aa8c3','#51c34a'],
                ['#c1c34a','#c38a4a','#c34a4a','#c34a6f'],


### PR DESCRIPTION
Displays a full color selector instead of the simple 8-element palette.  Original 8 colors are still available as a palette.