### PR TITLE
Renamed LeafLet 'L' to '_L'.

### DIFF
--- a/code/artifact.js
+++ b/code/artifact.js
@@ -24,7 +24,7 @@ window.artifact.setup = function() {
   // move the initial data request onto a very short timer. prevents thrown exceptions causing IITC boot failures
   setTimeout (artifact.requestData, 1);
 
-  artifact._layer = new L.LayerGroup();
+  artifact._layer = new _L.LayerGroup();
   addLayerGroup ('Artifacts', artifact._layer, true);
 
   $('#toolbox').append(' <a onclick="window.artifact.showArtifactList()" title="Show artifact portal list">Artifacts</a>');
@@ -162,7 +162,7 @@ window.artifact.updateLayer = function() {
   artifact._layer.clearLayers();
 
   $.each(artifact.portalInfo, function(guid,data) {
-    var latlng = L.latLng ([data._data.latE6/1E6, data._data.lngE6/1E6]);
+    var latlng = _L.latLng ([data._data.latE6/1E6, data._data.lngE6/1E6]);
 
     $.each(data, function(type,detail) {
 
@@ -175,14 +175,14 @@ window.artifact.updateLayer = function() {
         var iconSize = 100/2;
         var opacity = 1.0;
 
-        var icon = L.icon({
+        var icon = _L.icon({
           iconUrl: iconUrl,
           iconSize: [iconSize,iconSize],
           iconAnchor: [iconSize/2,iconSize/2],
           className: 'no-pointer-events'  // the clickable: false below still blocks events going through to the svg underneath
         });
 
-        var marker = L.marker (latlng, {icon: icon, clickable: false, keyboard: false, opacity: opacity });
+        var marker = _L.marker (latlng, {icon: icon, clickable: false, keyboard: false, opacity: opacity });
 
         artifact._layer.addLayer(marker);
 
@@ -193,14 +193,14 @@ window.artifact.updateLayer = function() {
         var iconSize = 60/2;
         var opacity = 0.6;
 
-        var icon = L.icon({
+        var icon = _L.icon({
           iconUrl: iconUrl,
           iconSize: [iconSize,iconSize],
           iconAnchor: [iconSize/2,iconSize/2],
           className: 'no-pointer-events'  // the clickable: false below still blocks events going through to the svg underneath
         });
 
-        var marker = L.marker (latlng, {icon: icon, clickable: false, keyboard: false, opacity: opacity });
+        var marker = _L.marker (latlng, {icon: icon, clickable: false, keyboard: false, opacity: opacity });
 
         artifact._layer.addLayer(marker);
 

--- a/code/boot.js
+++ b/code/boot.js
@@ -715,7 +715,7 @@ function boot() {
 try { console.log('Loading included JS now'); } catch(e) {}
 @@INCLUDERAW:external/leaflet-src.js@@
 window._L = L.noConflict();
-//window.L = window._L; // temporary backwards compability for 3rd party plugins
+window.L = window._L; // TODO: remove this. It's obsolete and only for 3rd party plugins
 (function (L) {@@INCLUDERAW:external/L.Geodesic.js@@})(_L);
 
 // modified version of https://github.com/shramov/leaflet-plugins. Also

--- a/code/boot.js
+++ b/code/boot.js
@@ -120,22 +120,22 @@ function createDefaultBaseMapLayers() {
   //var mqSubdomains = [ 'otile1','otile2', 'otile3', 'otile4' ];
   //var mqTileUrlPrefix = window.location.protocol !== 'https:' ? 'http://{s}.mqcdn.com' : 'https://{s}-s.mqcdn.com';
   //var mqMapOpt = {attribution: osmAttribution+', Tiles Courtesy of MapQuest', maxNativeZoom: 18, maxZoom: 21, subdomains: mqSubdomains};
-  //baseLayers['MapQuest OSM'] = new L.TileLayer(mqTileUrlPrefix+'/tiles/1.0.0/map/{z}/{x}/{y}.jpg',mqMapOpt);
+  //baseLayers['MapQuest OSM'] = new _L.TileLayer(mqTileUrlPrefix+'/tiles/1.0.0/map/{z}/{x}/{y}.jpg',mqMapOpt);
 
   // MapBox - https://www.mapbox.com/api-documentation/
   // Access MapBox via the GNOME Project proxy.
   // In the future, this URL will provide improved tiles from the GNOME Project with localized labels.
   var gnomeStreetUrl = 'https://gis.gnome.org/tiles/street/v1/{z}/{x}/{y}';
   var gnomeAerialUrl = 'https://gis.gnome.org/tiles/satellite/v1/{z}/{x}/{y}';
-  baseLayers['MapBox Street'] = L.tileLayer(gnomeStreetUrl);
-  baseLayers['MapBox Satellite'] = L.tileLayer(gnomeAerialUrl);
+  baseLayers['MapBox Street'] = _L.tileLayer(gnomeStreetUrl);
+  baseLayers['MapBox Satellite'] = _L.tileLayer(gnomeAerialUrl);
   
   // cartodb has some nice tiles too - both dark and light subtle maps - http://cartodb.com/basemaps/
   // (not available over https though - not on the right domain name anyway)
   var cartoAttr = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>';
   var cartoUrl = 'http://{s}.basemaps.cartocdn.com/{theme}/{z}/{x}/{y}.png';
-  baseLayers['CartoDB Dark Matter'] = L.tileLayer(cartoUrl,{attribution:cartoAttr,theme:'dark_all'});
-  baseLayers['CartoDB Positron'] = L.tileLayer(cartoUrl,{attribution:cartoAttr,theme:'light_all'});
+  baseLayers['CartoDB Dark Matter'] = _L.tileLayer(cartoUrl,{attribution:cartoAttr,theme:'dark_all'});
+  baseLayers['CartoDB Positron'] = _L.tileLayer(cartoUrl,{attribution:cartoAttr,theme:'light_all'});
 
 
   // we'll include google maps too - in the ingress default style, and a few other standard ones
@@ -151,11 +151,11 @@ function createDefaultBaseMapLayers() {
         { featureType:"transit", elementType:"all", stylers:[{visibility:"off"}] }
       ]
   };
-  baseLayers['Google Default Ingress Map'] = new L.Google('ROADMAP',{maxZoom:21, mapOptions:ingressGMapOptions});
-  baseLayers['Google Roads'] = new L.Google('ROADMAP',{maxZoom:21});
-  baseLayers['Google Satellite'] = new L.Google('SATELLITE',{maxZoom:21});
-  baseLayers['Google Hybrid'] = new L.Google('HYBRID',{maxZoom:21});
-  baseLayers['Google Terrain'] = new L.Google('TERRAIN',{maxZoom:15});
+  baseLayers['Google Default Ingress Map'] = new _L.Google('ROADMAP',{maxZoom:21, mapOptions:ingressGMapOptions});
+  baseLayers['Google Roads'] = new _L.Google('ROADMAP',{maxZoom:21});
+  baseLayers['Google Satellite'] = new _L.Google('SATELLITE',{maxZoom:21});
+  baseLayers['Google Hybrid'] = new _L.Google('HYBRID',{maxZoom:21});
+  baseLayers['Google Terrain'] = new _L.Google('TERRAIN',{maxZoom:15});
 
 
   return baseLayers;
@@ -169,7 +169,7 @@ window.setupMap = function() {
 
 
   // proper initial position is now delayed until all plugins are loaded and the base layer is set
-  window.map = new L.Map('map', {
+  window.map = new _L.Map('map', {
     center: [0,0],
     zoom: 1,
     zoomControl: (typeof android !== 'undefined' && android && android.showZoom) ? android.showZoom() : true,
@@ -179,16 +179,16 @@ window.setupMap = function() {
     bounceAtZoomLimits: false
   });
 
-  if (L.Path.CANVAS) {
+  if (_L.Path.CANVAS) {
     // for canvas, 2% overdraw only - to help performance
-    L.Path.CLIP_PADDING = 0.02;
-  } else if (L.Path.SVG) {
-    if (L.Browser.mobile) {
+    _L.Path.CLIP_PADDING = 0.02;
+  } else if (_L.Path.SVG) {
+    if (_L.Browser.mobile) {
       // mobile SVG - 10% ovredraw. might help performance?
-      L.Path.CLIP_PADDING = 0.1;
+      _L.Path.CLIP_PADDING = 0.1;
     } else {
       // for svg, 100% overdraw - so we have a full screen worth in all directions
-      L.Path.CLIP_PADDING = 1.0;
+      _L.Path.CLIP_PADDING = 1.0;
     }
   }
 
@@ -206,8 +206,8 @@ window.setupMap = function() {
   portalsFactionLayers = [];
   var portalsLayers = [];
   for(var i = 0; i <= 8; i++) {
-    portalsFactionLayers[i] = [L.layerGroup(), L.layerGroup(), L.layerGroup()];
-    portalsLayers[i] = L.layerGroup(portalsFactionLayers[i]);
+    portalsFactionLayers[i] = [_L.layerGroup(), _L.layerGroup(), _L.layerGroup()];
+    portalsLayers[i] = _L.layerGroup(portalsFactionLayers[i]);
     map.addLayer(portalsLayers[i]);
     var t = (i === 0 ? 'Unclaimed/Placeholder' : 'Level ' + i) + ' Portals';
     addLayers[t] = portalsLayers[i];
@@ -215,15 +215,15 @@ window.setupMap = function() {
     if(!isLayerGroupDisplayed(t, true)) hiddenLayer.push(portalsLayers[i]);
   }
 
-  fieldsFactionLayers = [L.layerGroup(), L.layerGroup(), L.layerGroup()];
-  var fieldsLayer = L.layerGroup(fieldsFactionLayers);
+  fieldsFactionLayers = [_L.layerGroup(), _L.layerGroup(), _L.layerGroup()];
+  var fieldsLayer = _L.layerGroup(fieldsFactionLayers);
   map.addLayer(fieldsLayer, true);
   addLayers['Fields'] = fieldsLayer;
   // Store it in hiddenLayer to remove later
   if(!isLayerGroupDisplayed('Fields', true)) hiddenLayer.push(fieldsLayer);
 
-  linksFactionLayers = [L.layerGroup(), L.layerGroup(), L.layerGroup()];
-  var linksLayer = L.layerGroup(linksFactionLayers);
+  linksFactionLayers = [_L.layerGroup(), _L.layerGroup(), _L.layerGroup()];
+  var linksLayer = _L.layerGroup(linksFactionLayers);
   map.addLayer(linksLayer, true);
   addLayers['Links'] = linksLayer;
   // Store it in hiddenLayer to remove later
@@ -233,7 +233,7 @@ window.setupMap = function() {
   // these layers don't actually contain any data. instead, every time they're added/removed from the map,
   // the matching sub-layers within the above portals/fields/links are added/removed from their parent with
   // the below 'onoverlayadd/onoverlayremove' events
-  var factionLayers = [L.layerGroup(), L.layerGroup(), L.layerGroup()];
+  var factionLayers = [_L.layerGroup(), _L.layerGroup(), _L.layerGroup()];
   for (var fac in factionLayers) {
     map.addLayer (factionLayers[fac]);
   }
@@ -284,7 +284,7 @@ window.setupMap = function() {
 
   var baseLayers = createDefaultBaseMapLayers();
 
-  window.layerChooser = new L.Control.Layers(baseLayers, addLayers);
+  window.layerChooser = new _L.Control.Layers(baseLayers, addLayers);
 
   // Remove the hidden layer after layerChooser built, to avoid messing up ordering of layers 
   $.each(hiddenLayer, function(ind, layer){
@@ -313,7 +313,7 @@ window.setupMap = function() {
 
   map.on('moveend', function(e) {
     // two limits on map position
-    // we wrap longitude (the L.LatLng 'wrap' method) - so we don't find ourselves looking beyond +-180 degrees
+    // we wrap longitude (the _L.LatLng 'wrap' method) - so we don't find ourselves looking beyond +-180 degrees
     // then latitude is clamped with the clampLatLng function (to the 85 deg north/south limits)
     var newPos = clampLatLng(map.getCenter().wrap());
     if (!map.getCenter().equals(newPos)) {
@@ -359,7 +359,7 @@ window.setupMap = function() {
 
 //adds a base layer to the map. done separately from the above, so that plugins that add base layers can be the default
 window.setMapBaseLayer = function() {
-  //create a map name -> layer mapping - depends on internals of L.Control.Layers
+  //create a map name -> layer mapping - depends on internals of _L.Control.Layers
   var nameToLayer = {};
   var firstLayer = null;
 
@@ -503,7 +503,7 @@ window.setupLayerChooserApi = function() {
   }
 
   //hook some additional code into the LayerControl so it's easy for the mobile app to interface with it
-  //WARNING: does depend on internals of the L.Control.Layers code
+  //WARNING: does depend on internals of the _L.Control.Layers code
   window.layerChooser.getLayers = function() {
     var baseLayers = new Array();
     var overlayLayers = new Array();
@@ -512,7 +512,7 @@ window.setupLayerChooserApi = function() {
       var obj = this._layers[i];
       var layerActive = window.map.hasLayer(obj.layer);
       var info = {
-        layerId: L.stamp(obj.layer),
+        layerId: _L.stamp(obj.layer),
         name: obj.name,
         active: layerActive
       }
@@ -566,7 +566,7 @@ window.setupLayerChooserApi = function() {
       }
     }
 
-    //below logic based on code in L.Control.Layers _onInputClick
+    //below logic based on code in _L.Control.Layers _onInputClick
     if(!obj.overlay) {
       this._map.setZoom(this._map.getZoom());
       this._map.fire('baselayerchange', {layer: obj.layer});
@@ -610,12 +610,12 @@ function boot() {
   var iconDefImage = '@@INCLUDEIMAGE:images/marker-icon.png@@';
   var iconDefRetImage = '@@INCLUDEIMAGE:images/marker-icon-2x.png@@';
 
-  L.Icon.Default = L.Icon.extend({options: {
+  _L.Icon.Default = _L.Icon.extend({options: {
     iconUrl: iconDefImage,
     iconRetinaUrl: iconDefRetImage,
-    iconSize: new L.Point(25, 41),
-    iconAnchor: new L.Point(12, 41),
-    popupAnchor: new L.Point(1, -34),
+    iconSize: new _L.Point(25, 41),
+    iconAnchor: new _L.Point(12, 41),
+    popupAnchor: new _L.Point(1, -34),
   }});
 
   window.extractFromStock();
@@ -707,7 +707,6 @@ function boot() {
   if (typeof android !== 'undefined' && android && android.bootFinished) {
     android.bootFinished();
   }
-
 }
 
 
@@ -715,12 +714,15 @@ function boot() {
 
 try { console.log('Loading included JS now'); } catch(e) {}
 @@INCLUDERAW:external/leaflet-src.js@@
-@@INCLUDERAW:external/L.Geodesic.js@@
+window._L = L.noConflict();
+//window.L = window._L; // temporary backwards compability for 3rd party plugins
+(function (L) {@@INCLUDERAW:external/L.Geodesic.js@@})(_L);
+
 // modified version of https://github.com/shramov/leaflet-plugins. Also
 // contains the default Ingress map style.
-@@INCLUDERAW:external/Google.js@@
+(function (L) {@@INCLUDERAW:external/Google.js@@})(_L);
 @@INCLUDERAW:external/autolink.js@@
-@@INCLUDERAW:external/oms.min.js@@
+(function (L) {@@INCLUDERAW:external/oms.min.js@@})(_L);
 
 try { console.log('done loading included JS'); } catch(e) {}
 

--- a/code/data_cache.js
+++ b/code/data_cache.js
@@ -7,7 +7,7 @@ window.DataCache = function() {
   this.REQUEST_CACHE_MAX_AGE = 5*60;  // maximum cache age. entries are deleted from the cache after this time
 
   //NOTE: characters are 16 bits (ECMAScript standard), so divide byte size by two for correct limit
-  if (L.Browser.mobile) {
+  if (_L.Browser.mobile) {
     // on mobile devices, smaller cache size
     this.REQUEST_CACHE_MAX_ITEMS = 300;  // if more than this many entries, expire early
     this.REQUEST_CACHE_MAX_CHARS = 5000000/2; // or more than this total size

--- a/code/debugging.js
+++ b/code/debugging.js
@@ -101,6 +101,6 @@ window.debug.console.overwriteNative = function() {
 }
 
 window.debug.console.overwriteNativeIfRequired = function() {
-  if(!window.console || L.Browser.mobile)
+  if(!window.console || _L.Browser.mobile)
     window.debug.console.overwriteNative();
 }

--- a/code/location.js
+++ b/code/location.js
@@ -25,7 +25,7 @@ window.getPosition = function() {
     var lat = parseInt(getURLParam('latE6'))/1E6 || 0.0;
     var lng = parseInt(getURLParam('lngE6'))/1E6 || 0.0;
     var z = parseInt(getURLParam('z')) || 17;
-    return {center: new L.LatLng(lat, lng), zoom: z};
+    return {center: new _L.LatLng(lat, lng), zoom: z};
   }
 
   if(getURLParam('ll')) {
@@ -33,7 +33,7 @@ window.getPosition = function() {
     var lat = parseFloat(getURLParam('ll').split(",")[0]) || 0.0;
     var lng = parseFloat(getURLParam('ll').split(",")[1]) || 0.0;
     var z = parseInt(getURLParam('z')) || 17;
-    return {center: new L.LatLng(lat, lng), zoom: z};
+    return {center: new _L.LatLng(lat, lng), zoom: z};
   }
 
   if(getURLParam('pll')) {
@@ -41,7 +41,7 @@ window.getPosition = function() {
     var lat = parseFloat(getURLParam('pll').split(",")[0]) || 0.0;
     var lng = parseFloat(getURLParam('pll').split(",")[1]) || 0.0;
     var z = parseInt(getURLParam('z')) || 17;
-    return {center: new L.LatLng(lat, lng), zoom: z};
+    return {center: new _L.LatLng(lat, lng), zoom: z};
   }
 
   if(readCookie('ingress.intelmap.lat') && readCookie('ingress.intelmap.lng')) {
@@ -53,10 +53,10 @@ window.getPosition = function() {
     if(lat < -90  || lat > 90) lat = 0.0;
     if(lng < -180 || lng > 180) lng = 0.0;
 
-    return {center: new L.LatLng(lat, lng), zoom: z};
+    return {center: new _L.LatLng(lat, lng), zoom: z};
   }
 
   setTimeout("window.map.locate({setView : true});", 50);
 
-  return {center: new L.LatLng(0.0, 0.0), zoom: 1};
+  return {center: new _L.LatLng(0.0, 0.0), zoom: 1};
 }

--- a/code/map_data_debug.js
+++ b/code/map_data_debug.js
@@ -3,10 +3,10 @@
 
 
 window.RenderDebugTiles = function() {
-  this.CLEAR_CHECK_TIME = L.Path.CANVAS ? 2.0 : 0.5;
+  this.CLEAR_CHECK_TIME = _L.Path.CANVAS ? 2.0 : 0.5;
   this.FADE_TIME = 2.0;
 
-  this.debugTileLayer = L.layerGroup();
+  this.debugTileLayer = _L.layerGroup();
   window.addLayerGroup("DEBUG Data Tiles", this.debugTileLayer, false);
 
   this.debugTileToRectangle = {};
@@ -23,10 +23,10 @@ window.RenderDebugTiles.prototype.reset = function() {
 window.RenderDebugTiles.prototype.create = function(id,bounds) {
   var s = {color: '#666', weight: 2, opacity: 0.4, fillColor: '#666', fillOpacity: 0.1, clickable: false};
 
-  var bounds = new L.LatLngBounds(bounds);
+  var bounds = new _L.LatLngBounds(bounds);
   bounds = bounds.pad(-0.02);
 
-  var l = L.rectangle(bounds,s);
+  var l = _L.rectangle(bounds,s);
   this.debugTileToRectangle[id] = l;
   this.debugTileLayer.addLayer(l);
   if (map.hasLayer(this.debugTileLayer)) {

--- a/code/map_data_render.js
+++ b/code/map_data_render.js
@@ -54,7 +54,7 @@ window.Render.prototype.clearLinksOutsideBounds = function(bounds) {
     // NOTE: our geodesic lines can have lots of intermediate points. the bounds calculation hasn't been optimised for this
     // so can be particularly slow. a simple bounds check based on start+end point will be good enough for this check
     var lls = l.getLatLngs();
-    var linkBounds = L.latLngBounds(lls);
+    var linkBounds = _L.latLngBounds(lls);
 
     if (!bounds.intersects(linkBounds)) {
       this.deleteLinkEntity(guid);
@@ -72,7 +72,7 @@ window.Render.prototype.clearFieldsOutsideBounds = function(bounds) {
     // NOTE: our geodesic polys can have lots of intermediate points. the bounds calculation hasn't been optimised for this
     // so can be particularly slow. a simple bounds check based on corner points will be good enough for this check
     var lls = f.getLatLngs();
-    var fieldBounds = L.latLngBounds([lls[0],lls[1]]).extend(lls[2]);
+    var fieldBounds = _L.latLngBounds([lls[0],lls[1]]).extend(lls[2]);
 
     if (!bounds.intersects(fieldBounds)) {
       this.deleteFieldEntity(guid);
@@ -314,7 +314,7 @@ window.Render.prototype.createPortalEntity = function(ent) {
   // the data returns unclaimed portals as level 1 - but IITC wants them treated as level 0
   if (team == TEAM_NONE) portalLevel = 0;
 
-  var latlng = L.latLng(ent[2][2]/1E6, ent[2][3]/1E6);
+  var latlng = _L.latLng(ent[2][2]/1E6, ent[2][3]/1E6);
 
   var data = decodeArray.portalSummary(ent[2]);
 
@@ -399,12 +399,12 @@ window.Render.prototype.createFieldEntity = function(ent) {
 
   var team = teamStringToId(ent[2][1]);
   var latlngs = [
-    L.latLng(data.points[0].latE6/1E6, data.points[0].lngE6/1E6),
-    L.latLng(data.points[1].latE6/1E6, data.points[1].lngE6/1E6),
-    L.latLng(data.points[2].latE6/1E6, data.points[2].lngE6/1E6)
+    _L.latLng(data.points[0].latE6/1E6, data.points[0].lngE6/1E6),
+    _L.latLng(data.points[1].latE6/1E6, data.points[1].lngE6/1E6),
+    _L.latLng(data.points[2].latE6/1E6, data.points[2].lngE6/1E6)
   ];
 
-  var poly = L.geodesicPolygon(latlngs, {
+  var poly = _L.geodesicPolygon(latlngs, {
     fillColor: COLORS[team],
     fillOpacity: 0.25,
     stroke: false,
@@ -467,10 +467,10 @@ window.Render.prototype.createLinkEntity = function(ent,faked) {
 
   var team = teamStringToId(ent[2][1]);
   var latlngs = [
-    L.latLng(data.oLatE6/1E6, data.oLngE6/1E6),
-    L.latLng(data.dLatE6/1E6, data.dLngE6/1E6)
+    _L.latLng(data.oLatE6/1E6, data.oLngE6/1E6),
+    _L.latLng(data.dLatE6/1E6, data.dLngE6/1E6)
   ];
-  var poly = L.geodesicPolyline(latlngs, {
+  var poly = _L.geodesicPolyline(latlngs, {
     color: COLORS[team],
     opacity: 1,
     weight: faked ? 1 : 2,

--- a/code/map_data_request.js
+++ b/code/map_data_request.js
@@ -57,7 +57,7 @@ window.MapDataRequest = function() {
   // render queue
   // number of items to process in each render pass. there are pros and cons to smaller and larger values
   // (however, if using leaflet canvas rendering, it makes sense to push as much as possible through every time)
-  this.RENDER_BATCH_SIZE = L.Path.CANVAS ? 1E9 : 1500;
+  this.RENDER_BATCH_SIZE = _L.Path.CANVAS ? 1E9 : 1500;
 
   // delay before repeating the render loop. this gives a better chance for user interaction
   this.RENDER_PAUSE = (typeof android === 'undefined') ? 0.1 : 0.2; //100ms desktop, 200ms mobile
@@ -215,7 +215,7 @@ window.MapDataRequest.prototype.refresh = function() {
 //DEBUG: resize the bounds so we only retrieve some data
 //bounds = bounds.pad(-0.4);
 
-//var debugrect = L.rectangle(bounds,{color: 'red', fill: false, weight: 4, opacity: 0.8}).addTo(map);
+//var debugrect = _L.rectangle(bounds,{color: 'red', fill: false, weight: 4, opacity: 0.8}).addTo(map);
 //setTimeout (function(){ map.removeLayer(debugrect); }, 10*1000);
 
   var x1 = lngToTile(bounds.getWest(), tileParams);
@@ -224,11 +224,11 @@ window.MapDataRequest.prototype.refresh = function() {
   var y2 = latToTile(bounds.getSouth(), tileParams);
 
   // calculate the full bounds for the data - including the part of the tiles off the screen edge
-  var dataBounds = L.latLngBounds([
+  var dataBounds = _L.latLngBounds([
     [tileToLat(y2+1,tileParams), tileToLng(x1,tileParams)],
     [tileToLat(y1,tileParams), tileToLng(x2+1,tileParams)]
   ]);
-//var debugrect2 = L.rectangle(dataBounds,{color: 'magenta', fill: false, weight: 4, opacity: 0.8}).addTo(map);
+//var debugrect2 = _L.rectangle(dataBounds,{color: 'magenta', fill: false, weight: 4, opacity: 0.8}).addTo(map);
 //setTimeout (function(){ map.removeLayer(debugrect2); }, 10*1000);
 
   // store the parameters used for fetching the data. used to prevent unneeded refreshes after move/zoom
@@ -296,7 +296,7 @@ window.MapDataRequest.prototype.refresh = function() {
 
         var latCenter = (latNorth+latSouth)/2;
         var lngCenter = (lngEast+lngWest)/2;
-        var tileLatLng = L.latLng(latCenter,lngCenter);
+        var tileLatLng = _L.latLng(latCenter,lngCenter);
 
         var tilePoint = map.project(tileLatLng, mapZoom);
 

--- a/code/ornaments.js
+++ b/code/ornaments.js
@@ -16,7 +16,7 @@ window.ornaments.OVERLAY_OPACITY = 0.6;
 
 window.ornaments.setup = function() {
   window.ornaments._portals = {};
-  window.ornaments._layer = L.layerGroup();
+  window.ornaments._layer = _L.layerGroup();
   window.addLayerGroup('Ornaments', window.ornaments._layer, true);
 }
 
@@ -35,14 +35,14 @@ window.ornaments.addPortal = function(portal) {
 
   if (portal.options.data.ornaments) {
     window.ornaments._portals[guid] = portal.options.data.ornaments.map(function(ornament) {
-      var icon = L.icon({
+      var icon = _L.icon({
         iconUrl: "//commondatastorage.googleapis.com/ingress.com/img/map_icons/marker_images/"+ornament+".png",
         iconSize: [size, size],
         iconAnchor: [size/2,size/2],
         className: 'no-pointer-events'  // the clickable: false below still blocks events going through to the svg underneath
       });
 
-      return L.marker(latlng, {icon: icon, clickable: false, keyboard: false, opacity: window.ornaments.OVERLAY_OPACITY }).addTo(window.ornaments._layer);
+      return _L.marker(latlng, {icon: icon, clickable: false, keyboard: false, opacity: window.ornaments.OVERLAY_OPACITY }).addTo(window.ornaments._layer);
     });
   }
 }

--- a/code/portal_data.js
+++ b/code/portal_data.js
@@ -61,7 +61,7 @@ window.findPortalLatLng = function(guid) {
   // not found in portals - try the cached (and possibly stale) details - good enough for location
   var details = portalDetail.get(guid);
   if (details) {
-    return L.latLng (details.latE6/1E6, details.lngE6/1E6);
+    return _L.latLng (details.latE6/1E6, details.lngE6/1E6);
   }
 
   // now try searching through fields
@@ -70,7 +70,7 @@ window.findPortalLatLng = function(guid) {
 
     for (var i in f.points) {
       if (f.points[i].guid == guid) {
-        return L.latLng (f.points[i].latE6/1E6, f.points[i].lngE6/1E6);
+        return _L.latLng (f.points[i].latE6/1E6, f.points[i].lngE6/1E6);
       }
     }
   }
@@ -79,10 +79,10 @@ window.findPortalLatLng = function(guid) {
   for (var lguid in window.links) {
     var l = window.links[lguid].options.data;
     if (l.oGuid == guid) {
-      return L.latLng (l.oLatE6/1E6, l.oLngE6/1E6);
+      return _L.latLng (l.oLatE6/1E6, l.oLngE6/1E6);
     }
     if (l.dGuid == guid) {
-      return L.latLng (l.dLatE6/1E6, l.dLngE6/1E6);
+      return _L.latLng (l.dLatE6/1E6, l.dLngE6/1E6);
     }
   }
 

--- a/code/portal_detail_display.js
+++ b/code/portal_detail_display.js
@@ -228,17 +228,17 @@ window.setPortalIndicators = function(p) {
     if (d) {
       var range = getPortalRange(d);
       portalRangeIndicator = (range.range > 0
-          ? L.geodesicCircle(coord, range.range, {
+          ? _L.geodesicCircle(coord, range.range, {
               fill: false,
               color: RANGE_INDICATOR_COLOR,
               weight: 3,
               dashArray: range.isLinkable ? undefined : "10,10",
               clickable: false })
-          : L.circle(coord, range.range, { fill: false, stroke: false, clickable: false })
+          : _L.circle(coord, range.range, { fill: false, stroke: false, clickable: false })
         ).addTo(map);
     }
 
-    portalAccessIndicator = L.circle(coord, HACK_RANGE,
+    portalAccessIndicator = _L.circle(coord, HACK_RANGE,
       { fill: false, color: ACCESS_INDICATOR_COLOR, weight: 2, clickable: false }
     ).addTo(map);
   }

--- a/code/portal_marker.js
+++ b/code/portal_marker.js
@@ -4,7 +4,7 @@
 
 window.portalMarkerScale = function() {
   var zoom = map.getZoom();
-  if (L.Browser.mobile)
+  if (_L.Browser.mobile)
     return zoom >= 16 ? 1.5 : zoom >= 14 ? 1.2 : zoom >= 11 ? 1.0 : zoom >= 8 ? 0.65 : 0.5;
   else
     return zoom >= 14 ? 1 : zoom >= 11 ? 0.8 : zoom >= 8 ? 0.65 : 0.5;
@@ -14,9 +14,9 @@ window.portalMarkerScale = function() {
 window.createMarker = function(latlng, data) {
   var styleOptions = window.getMarkerStyleOptions(data);
 
-  var options = L.extend({}, data, styleOptions, { clickable: true });
+  var options = _L.extend({}, data, styleOptions, { clickable: true });
 
-  var marker = L.circleMarker(latlng, options);
+  var marker = _L.circleMarker(latlng, options);
 
   highlightPortal(marker);
 

--- a/code/search.js
+++ b/code/search.js
@@ -14,8 +14,8 @@ addHook('search', function(query) {});
 `result` may have the following members (`title` is required, as well as one of `position` and `bounds`):
 - `title`: the label for this result. Will be interpreted as HTML, so make sure to escape properly.
 - `description`: secondary information for this result. Will be interpreted as HTML, so make sure to escape properly.
-- `position`: a L.LatLng object describing the position of this result
-- `bounds`: a L.LatLngBounds object describing the bounds of this result
+- `position`: a _L.LatLng object describing the position of this result
+- `bounds`: a _L.LatLngBounds object describing the bounds of this result
 - `layer`: a ILayer to be added to the map when the user selects this search result. Will be generated if not set.
   Set to `null` to prevent the result from being added to the map.
 - `icon`: a URL to a icon to display in the result list. Should be 12x12.
@@ -134,7 +134,7 @@ window.search.Query.prototype.onResultSelected = function(result, ev) {
   }
 
   if(result.layer !== null && !result.layer) {
-    result.layer = L.layerGroup();
+    result.layer = _L.layerGroup();
 
     if(result.position) {
       createGenericMarker(result.position, 'red', {
@@ -143,7 +143,7 @@ window.search.Query.prototype.onResultSelected = function(result, ev) {
     }
 
     if(result.bounds) {
-      L.rectangle(result.bounds, {
+      _L.rectangle(result.bounds, {
         title: result.title,
         clickable: false,
         color: 'red',
@@ -263,7 +263,7 @@ addHook('search', function(query) {
   locations.forEach(function(location) {
     var pair = location.split(',').map(function(s) { return parseFloat(s).toFixed(6); });
     var ll = pair.join(",");
-    var latlng = L.latLng(pair.map(function(s) { return parseFloat(s); }));
+    var latlng = _L.latLng(pair.map(function(s) { return parseFloat(s); }));
     if(added[ll]) return;
     added[ll] = true;
 
@@ -305,12 +305,12 @@ addHook('search', function(query) {
       var result = {
         title: item.display_name,
         description: 'Type: ' + item.type,
-        position: L.latLng(parseFloat(item.lat), parseFloat(item.lon)),
+        position: _L.latLng(parseFloat(item.lat), parseFloat(item.lon)),
         icon: item.icon,
       };
 
       if(item.geojson) {
-        result.layer = L.geoJson(item.geojson, {
+        result.layer = _L.geoJson(item.geojson, {
           clickable: false,
           color: 'red',
           opacity: 0.7,
@@ -324,9 +324,9 @@ addHook('search', function(query) {
 
       var b = item.boundingbox;
       if(b) {
-        var southWest = new L.LatLng(b[0], b[2]),
-            northEast = new L.LatLng(b[1], b[3]);
-        result.bounds = new L.LatLngBounds(southWest, northEast);
+        var southWest = new _L.LatLng(b[0], b[2]),
+            northEast = new _L.LatLng(b[1], b[3]);
+        result.bounds = new _L.LatLngBounds(southWest, northEast);
       }
 
       query.addResult(result);

--- a/code/utils_misc.js
+++ b/code/utils_misc.js
@@ -272,7 +272,7 @@ window.selectPortalByLatLng = function(lat, lng) {
   if(lng === undefined && lat instanceof Array) {
     lng = lat[1];
     lat = lat[0];
-  } else if(lng === undefined && lat instanceof L.LatLng) {
+  } else if(lng === undefined && lat instanceof _L.LatLng) {
     lng = lat.lng;
     lat = lat.lat;
   }
@@ -443,11 +443,11 @@ window.clampLng = function(lng) {
 
 
 window.clampLatLng = function(latlng) {
-  return new L.LatLng ( clampLat(latlng.lat), clampLng(latlng.lng) );
+  return new _L.LatLng ( clampLat(latlng.lat), clampLng(latlng.lng) );
 }
 
 window.clampLatLngBounds = function(bounds) {
-  return new L.LatLngBounds ( clampLatLng(bounds.getSouthWest()), clampLatLng(bounds.getNorthEast()) );
+  return new _L.LatLngBounds ( clampLatLng(bounds.getSouthWest()), clampLatLng(bounds.getNorthEast()) );
 }
 
 window.getGenericMarkerSvg = function(color) {
@@ -457,9 +457,9 @@ window.getGenericMarkerSvg = function(color) {
 }
 
 window.getGenericMarkerIcon = function(color,className) {
-  return L.divIcon({
-    iconSize: new L.Point(25, 41),
-    iconAnchor: new L.Point(12, 41),
+  return _L.divIcon({
+    iconSize: new _L.Point(25, 41),
+    iconAnchor: new _L.Point(12, 41),
     html: getGenericMarkerSvg(color),
     className: className || 'leaflet-iitc-divicon-generic-marker'
   });
@@ -472,18 +472,18 @@ window.createGenericMarker = function(ll,color,options) {
     icon: getGenericMarkerIcon(color || '#a24ac3')
   }, options);
 
-  return L.marker(ll, markerOpt);
+  return _L.marker(ll, markerOpt);
 }
 
 
 
 // Fix Leaflet: handle touchcancel events in Draggable
-L.Draggable.prototype._onDownOrig = L.Draggable.prototype._onDown;
-L.Draggable.prototype._onDown = function(e) {
-  L.Draggable.prototype._onDownOrig.apply(this, arguments);
+_L.Draggable.prototype._onDownOrig = _L.Draggable.prototype._onDown;
+_L.Draggable.prototype._onDown = function(e) {
+  _L.Draggable.prototype._onDownOrig.apply(this, arguments);
 
   if(e.type === "touchstart") {
-    L.DomEvent.on(document, "touchcancel", this._onUp, this);
+    _L.DomEvent.on(document, "touchcancel", this._onUp, this);
   }
 }
 

--- a/mobile/plugins/user-location.user.js
+++ b/mobile/plugins/user-location.user.js
@@ -33,20 +33,20 @@ window.plugin.userLocation.setup = function() {
 
   var cssClass = PLAYER.team === 'RESISTANCE' ? 'res' : 'enl';
 
-  var icon = L.divIcon({
-    iconSize: L.point(32, 32),
-    iconAnchor: L.point(16, 16),
+  var icon = _L.divIcon({
+    iconSize: _L.point(32, 32),
+    iconAnchor: _L.point(16, 16),
     className: 'user-location',
     html: '<div class="container ' + cssClass + ' circle"><div class="outer"></div><div class="inner"></div></div>'
   });
 
-  var marker = L.marker(new L.LatLng(0,0), {
+  var marker = _L.marker(new _L.LatLng(0,0), {
     icon: icon,
     zIndexOffset: 300,
     clickable: false
   });
 
-  var circle = new L.Circle(new L.LatLng(0,0), 40, {
+  var circle = new _L.Circle(new _L.LatLng(0,0), 40, {
     stroke: false,
     opacity: 0.7,
     fillOpacity: 1,
@@ -55,7 +55,7 @@ window.plugin.userLocation.setup = function() {
     clickable: false
   });
 
-  window.plugin.userLocation.locationLayer = new L.LayerGroup();
+  window.plugin.userLocation.locationLayer = new _L.LayerGroup();
 
   marker.addTo(window.plugin.userLocation.locationLayer);
   window.plugin.userLocation.locationLayer.addTo(window.map);
@@ -70,7 +70,7 @@ window.plugin.userLocation.setup = function() {
 };
 
 window.plugin.userLocation.onZoomEnd = function() {
-  if(window.map.getZoom() < 16 || L.Path.CANVAS) {
+  if(window.map.getZoom() < 16 || _L.Path.CANVAS) {
     if (window.plugin.userLocation.locationLayer.hasLayer(window.plugin.userLocation.circle))
       window.plugin.userLocation.locationLayer.removeLayer(window.plugin.userLocation.circle);
   } else {
@@ -87,12 +87,12 @@ window.plugin.userLocation.locate = function(lat, lng, accuracy, persistentZoom)
     return;
   }
 
-  var latlng = new L.LatLng(lat, lng);
+  var latlng = new _L.LatLng(lat, lng);
 
   var latAccuracy = 180 * accuracy / 40075017;
-  var lngAccuracy = latAccuracy / Math.cos(L.LatLng.DEG_TO_RAD * lat);
+  var lngAccuracy = latAccuracy / Math.cos(_L.LatLng.DEG_TO_RAD * lat);
 
-  var zoom = window.map.getBoundsZoom(L.latLngBounds(
+  var zoom = window.map.getBoundsZoom(_L.latLngBounds(
     [lat - latAccuracy, lng - lngAccuracy],
     [lat + latAccuracy, lng + lngAccuracy]));
 
@@ -112,7 +112,7 @@ window.plugin.userLocation.locate = function(lat, lng, accuracy, persistentZoom)
 window.plugin.userLocation.onLocationChange = function(lat, lng) {
   if(!window.plugin.userLocation.marker) return;
 
-  var latlng = new L.LatLng(lat, lng);
+  var latlng = new _L.LatLng(lat, lng);
   window.plugin.userLocation.marker.setLatLng(latlng);
   window.plugin.userLocation.circle.setLatLng(latlng);
 

--- a/plugins/add-kml.user.js
+++ b/plugins/add-kml.user.js
@@ -27,7 +27,7 @@ window.plugin.overlayKML = function() {};
 
 window.plugin.overlayKML.loadExternals = function() {
   try { console.log('Loading leaflet.filelayer JS now'); } catch(e) {}
-  @@INCLUDERAW:external/leaflet.filelayer.js@@
+  (function (L) {@@INCLUDERAW:external/leaflet.filelayer.js@@})(_L);
   try { console.log('done loading leaflet.filelayer JS'); } catch(e) {}
 
   if (window.requestFile !== undefined) {
@@ -57,18 +57,18 @@ window.plugin.overlayKML.loadExternals = function() {
         var zoomName = 'leaflet-control-filelayer leaflet-control-zoom',
           barName = 'leaflet-bar',
           partName = barName + '-part',
-          container = L.DomUtil.create('div', zoomName + ' ' + barName);
-        var link = L.DomUtil.create('a', zoomName + '-in ' + partName, container);
-        link.innerHTML = L.Control.FileLayerLoad.LABEL;
+          container = _L.DomUtil.create('div', zoomName + ' ' + barName);
+        var link = _L.DomUtil.create('a', zoomName + '-in ' + partName, container);
+        link.innerHTML = _L.Control.FileLayerLoad.LABEL;
         link.href = '#';
-        link.title = L.Control.FileLayerLoad.TITLE;
+        link.title = _L.Control.FileLayerLoad.TITLE;
 
-        var stop = L.DomEvent.stopPropagation;
-        L.DomEvent
+        var stop = _L.DomEvent.stopPropagation;
+        _L.DomEvent
           .on(link, 'click', stop)
           .on(link, 'mousedown', stop)
           .on(link, 'dblclick', stop)
-          .on(link, 'click', L.DomEvent.preventDefault)
+          .on(link, 'click', _L.DomEvent.preventDefault)
           .on(link, 'click', function (e) {
             window.requestFile(function(filename, content) {
               _fileLayerLoad.getLoader().parse(content, filename);
@@ -78,13 +78,13 @@ window.plugin.overlayKML.loadExternals = function() {
         return container;
       }
     };
-    L.Control.FileLayerLoad.include(FileLayerLoadMixin);
+    _L.Control.FileLayerLoad.include(FileLayerLoadMixin);
 
     try { console.log('done loading android webview extensions for leaflet.filelayer JS'); } catch(e) {}
   }
 
   try { console.log('Loading KML JS now'); } catch(e) {}
-  @@INCLUDERAW:external/KML.js@@
+  (function (L) {@@INCLUDERAW:external/KML.js@@}(_L))
   try { console.log('done loading KML JS'); } catch(e) {}
 
   try { console.log('Loading togeojson JS now'); } catch(e) {}
@@ -99,8 +99,8 @@ var _fileLayerLoad = null;
 window.plugin.overlayKML.load = function() {
   // Provide popup window allow user to select KML to overlay
 	
-  L.Icon.Default.imagePath = '@@INCLUDEIMAGE:images/marker-icon.png@@';
-  var KMLIcon = L.icon({
+  _L.Icon.Default.imagePath = '@@INCLUDEIMAGE:images/marker-icon.png@@';
+  var KMLIcon = _L.icon({
     iconUrl: '@@INCLUDEIMAGE:images/marker-icon.png@@',
 
     iconSize:     [16, 24], // size of the icon
@@ -108,12 +108,12 @@ window.plugin.overlayKML.load = function() {
     popupAnchor:  [-3, 16] // point from which the popup should open relative to the iconAnchor
   });
   
-  L.Control.FileLayerLoad.LABEL = '<img src="@@INCLUDEIMAGE:images/open-folder-icon_sml.png@@" alt="Open" />';
-  _fileLayerLoad = L.Control.fileLayerLoad({
+  _L.Control.FileLayerLoad.LABEL = '<img src="@@INCLUDEIMAGE:images/open-folder-icon_sml.png@@" alt="Open" />';
+  _fileLayerLoad = _L.Control.fileLayerLoad({
     fitBounds: true,
     layerOptions: {
       pointToLayer: function (data, latlng) {
-      return L.marker(latlng, {icon: KMLIcon});
+      return _L.marker(latlng, {icon: KMLIcon});
     }},
   });
   _fileLayerLoad.addTo(map);

--- a/plugins/basemap-bing.user.js
+++ b/plugins/basemap-bing.user.js
@@ -25,7 +25,7 @@
 window.plugin.mapBing = function() {};
 
 window.plugin.mapBing.setupBingLeaflet = function() {
-@@INCLUDERAW:external/Bing.js@@
+  (function (L) {@@INCLUDERAW:external/Bing.js@@})(_L);
 }
 
 
@@ -42,9 +42,9 @@ window.plugin.mapBing.setup = function() {
   };
 
   // bing maps has an annual usage limit, which will likely be hit in 6 months at this time.
-  // it seems that the usage is counted on initialising the L.BingLayer, when the metadata is retrieved.
+  // it seems that the usage is counted on initialising the _L.BingLayer, when the metadata is retrieved.
   // so, we'll create some dummy layers and add those to the map, then, the first time a layer is added,
-  // create the L.BingLayer. This will eliminate all usage for users who install but don't use the map,
+  // create the _L.BingLayer. This will eliminate all usage for users who install but don't use the map,
   // and only create usage for the map layers actually selected in use
 
   var bingMapContainers = [];
@@ -52,18 +52,18 @@ window.plugin.mapBing.setup = function() {
   for (type in bingTypes) {
     var name = bingTypes[type];
 
-    bingMapContainers[type] = new L.LayerGroup();
+    bingMapContainers[type] = new _L.LayerGroup();
     layerChooser.addBaseLayer(bingMapContainers[type], 'Bing '+name);
   }
 
-  // now a leaflet event to catch base layer changes and create a L.BingLayer when needed
+  // now a leaflet event to catch base layer changes and create a _L.BingLayer when needed
   map.on('baselayerchange', function(e) {
     for (type in bingMapContainers) {
       if (e.layer == bingMapContainers[type]) {
         if (bingMapContainers[type].getLayers().length == 0) {
           // dummy layer group is empty - create the bing layer
           console.log('basemap-bing: creating '+type+' layer');
-          var bingMap = new L.BingLayer (bingApiKey, {type: type, maxNativeZoom: 19, maxZoom: 21});
+          var bingMap = new _L.BingLayer (bingApiKey, {type: type, maxNativeZoom: 19, maxZoom: 21});
           bingMapContainers[type].addLayer(bingMap);
         }
       }

--- a/plugins/basemap-blank.user.js
+++ b/plugins/basemap-blank.user.js
@@ -29,8 +29,8 @@ window.plugin.mapTileBlank = function() {};
 window.plugin.mapTileBlank.addLayer = function() {
 
   var blankOpt = {attribution: '', maxNativeZoom: 18, maxZoom: 21};
-  var blankWhite = new L.TileLayer('@@INCLUDEIMAGE:images/basemap-blank-tile-white.png@@', blankOpt);
-  var blankBlack = new L.TileLayer('@@INCLUDEIMAGE:images/basemap-blank-tile-black.png@@', blankOpt);
+  var blankWhite = new _L.TileLayer('@@INCLUDEIMAGE:images/basemap-blank-tile-white.png@@', blankOpt);
+  var blankBlack = new _L.TileLayer('@@INCLUDEIMAGE:images/basemap-blank-tile-black.png@@', blankOpt);
 
   layerChooser.addBaseLayer(blankWhite, "Blank Map (White)");
   layerChooser.addBaseLayer(blankBlack, "Blank Map (Black)");

--- a/plugins/basemap-gmaps-gray.user.js
+++ b/plugins/basemap-gmaps-gray.user.js
@@ -41,7 +41,7 @@ window.plugin.grayGMaps.addLayer = function() {
     ]
   };
 
-  var grayGMaps = new L.Google('ROA#DMAP',{maxZoom:21, mapOptions: grayGMapsOptions});
+  var grayGMaps = new _L.Google('ROA#DMAP',{maxZoom:21, mapOptions: grayGMapsOptions});
 
   layerChooser.addBaseLayer(grayGMaps, "Google Gray");
 };

--- a/plugins/basemap-kartverket.user.js
+++ b/plugins/basemap-kartverket.user.js
@@ -31,8 +31,8 @@ window.plugin.mapTileKartverketMap.addLayer = function() {
   // Map data from Kartverket (http://statkart.no/en/)
   kartverketAttribution = 'Map data © Kartverket';
   var kartverketOpt = {attribution: kartverketAttribution, maxNativeZoom: 18, maxZoom: 21, subdomains: ['opencache', 'opencache2', 'opencache3']};
-  var kartverketTopo2 = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2&zoom={z}&x={x}&y={y}', kartverketOpt);
-  var kartverketTopo2Grayscale = new L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2graatone&zoom={z}&x={x}&y={y}', kartverketOpt);
+  var kartverketTopo2 = new _L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2&zoom={z}&x={x}&y={y}', kartverketOpt);
+  var kartverketTopo2Grayscale = new _L.TileLayer('http://{s}.statkart.no/gatekeeper/gk/gk.open_gmaps?layers=topo2graatone&zoom={z}&x={x}&y={y}', kartverketOpt);
 
   layerChooser.addBaseLayer(kartverketTopo2, "Norway Topo");
   layerChooser.addBaseLayer(kartverketTopo2Grayscale, "Norway Topo Grayscale");

--- a/plugins/basemap-mapquest-open-aerial.user.js
+++ b/plugins/basemap-mapquest-open-aerial.user.js
@@ -32,7 +32,7 @@ window.plugin.mapTileMapQuestSat.addLayer = function() {
   var mqTileUrlPrefix = window.location.protocol !== 'https:' ? 'http://{s}.mqcdn.com' : 'https://{s}-s.mqcdn.com';
   //MapQuest satellite coverage outside of the US is rather limited - so not really worth having as we have google as an op!
   var mqSatOpt = {attribution: 'Portions Courtesy NASA/JPL-Caltech and U.S. Depart. of Agriculture, Farm Service Agency', maxNativeZoom: 18, maxZoom: 21, subdomains: mqSubdomains};
-  var mqSat = new L.TileLayer('http://{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg',mqSatOpt);
+  var mqSat = new _L.TileLayer('http://{s}.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.jpg',mqSatOpt);
 
   layerChooser.addBaseLayer(mqSat, "MapQuest Open Satellite");
 };

--- a/plugins/basemap-nokia-ovi.user.js
+++ b/plugins/basemap-nokia-ovi.user.js
@@ -41,7 +41,7 @@ window.plugin.mapNokiaOvi.setup = function() {
   $.each(oviStyles, function(style,data) {
     oviOpt['style'] = style;
     oviOpt['type'] = data.type;
-    var oviMap = new L.TileLayer('http://{s}.maptile.maps.svc.ovi.com/maptiler/maptile/newest/{style}/{z}/{x}/{y}/256/{type}', oviOpt);
+    var oviMap = new _L.TileLayer('http://{s}.maptile.maps.svc.ovi.com/maptiler/maptile/newest/{style}/{z}/{x}/{y}/256/{type}', oviOpt);
     layerChooser.addBaseLayer(oviMap, 'Nokia OVI '+data.name);
   });
 

--- a/plugins/basemap-opencyclemap.user.js
+++ b/plugins/basemap-opencyclemap.user.js
@@ -43,7 +43,7 @@ window.plugin.mapTileOpenCycleMap = {
     };
 
     for(var i in layers) {
-      var layer = new L.TileLayer('http://{s}.tile.thunderforest.com/' + i + '/{z}/{x}/{y}.png', ocmOpt);
+      var layer = new _L.TileLayer('http://{s}.tile.thunderforest.com/' + i + '/{z}/{x}/{y}.png', ocmOpt);
       layerChooser.addBaseLayer(layer, 'Thunderforest ' + layers[i]);
     }
   },

--- a/plugins/basemap-openstreetmap.user.js
+++ b/plugins/basemap-openstreetmap.user.js
@@ -41,7 +41,7 @@ window.plugin.mapTileOpenStreetMap = {
     };
 
     for(var url in layers) {
-      var layer = new L.TileLayer(url, osmOpt);
+      var layer = new _L.TileLayer(url, osmOpt);
       layerChooser.addBaseLayer(layer, layers[url]);
     }
   },

--- a/plugins/basemap-stamen.user.js
+++ b/plugins/basemap-stamen.user.js
@@ -50,7 +50,7 @@ window.plugin.mapTileStamen.addLayer = function() {
     var minZoom = info[2];
     var maxZoom = info[3];
 
-    var mapLayer = new L.TileLayer (baseUrl+'{layer}/{z}/{x}/{y}.{type}', {
+    var mapLayer = new _L.TileLayer (baseUrl+'{layer}/{z}/{x}/{y}.{type}', {
       attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>.',
       subdomains: 'abcd',    
       layer: layer,

--- a/plugins/basemap-yandex.user.js
+++ b/plugins/basemap-yandex.user.js
@@ -27,13 +27,8 @@
 window.plugin.mapTileYandex = function() {};
 
 window.plugin.mapTileYandex.leafletSetup = function() {
-
-//include Yandex.js start
-@@INCLUDERAW:external/Yandex.js@@
-//include Yandex.js end
-
+  (function (L) {@@INCLUDERAW:external/Yandex.js@@})(_L);
 }
-
 
 
 window.plugin.mapTileYandex.setup = function() {
@@ -52,7 +47,7 @@ window.plugin.mapTileYandex.setup = function() {
   var layers = {};
 
   $.each(yStyles, function(key,value) {
-    layers[key] = new L.LayerGroup();
+    layers[key] = new _L.LayerGroup();
     layerChooser.addBaseLayer(layers[key], 'Yandex '+value);
   });
 
@@ -60,7 +55,7 @@ window.plugin.mapTileYandex.setup = function() {
     window.plugin.mapTileYandex.leafletSetup();
     var yOpt = {maxZoom: 18};
     $.each(layers, function(key,layer) {
-      var yMap = new L.Yandex(key, yOpt);
+      var yMap = new _L.Yandex(key, yOpt);
       layer.addLayer(yMap);
     });
   }

--- a/plugins/bookmarks-by-zaso.user.js
+++ b/plugins/bookmarks-by-zaso.user.js
@@ -507,7 +507,7 @@
           title: escapeHtmlSpecialChars(bookmark.label),
           description: 'Map in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
           icon: '@@INCLUDEIMAGE:images/icon-bookmark-map.png@@',
-          position: L.latLng(bookmark.latlng.split(",")),
+          position: _L.latLng(bookmark.latlng.split(",")),
           zoom: bookmark.z,
           onSelected: window.plugin.bookmarks.onSearchResultSelected,
         });
@@ -522,7 +522,7 @@
           title: escapeHtmlSpecialChars(bookmark.label),
           description: 'Bookmark in folder "' + escapeHtmlSpecialChars(folder.label) + '"',
           icon: '@@INCLUDEIMAGE:images/icon-bookmark.png@@',
-          position: L.latLng(bookmark.latlng.split(",")),
+          position: _L.latLng(bookmark.latlng.split(",")),
           guid: bookmark.guid,
           onSelected: window.plugin.bookmarks.onSearchResultSelected,
         });
@@ -830,10 +830,10 @@
 
       var layer, layerType;
       if(latlngs.length == 2) {
-        layer = L.geodesicPolyline(latlngs, window.plugin.drawTools.lineOptions);
+        layer = _L.geodesicPolyline(latlngs, window.plugin.drawTools.lineOptions);
         layerType = 'polyline';
       } else {
-        layer = L.geodesicPolygon(latlngs, window.plugin.drawTools.polygonOptions);
+        layer = _L.geodesicPolygon(latlngs, window.plugin.drawTools.polygonOptions);
         layerType = 'polygon';
       }
 
@@ -878,14 +878,14 @@
     }
 
     if(latlngs.length == 2) {
-      var distance = L.latLng(latlngs[0]).distanceTo(latlngs[1]);
+      var distance = _L.latLng(latlngs[0]).distanceTo(latlngs[1]);
       text = 'Distance between portals: ' + formatDistance(distance);
       color = "";
     } else if(latlngs.length == 3) {
       var longdistance = false;
       var distances = latlngs.map(function(ll1, i, latlngs) {
         var ll2 = latlngs[(i+1)%3];
-        return formatDistance(L.latLng(ll1).distanceTo(ll2));
+        return formatDistance(_L.latLng(ll1).distanceTo(ll2));
       });
       text = 'Distances: ' + distances.join(", ");
       color = "";
@@ -1087,9 +1087,9 @@
   }
 
   window.plugin.bookmarks.addStar = function(guid, latlng, lbl) {
-    var star = L.marker(latlng, {
+    var star = _L.marker(latlng, {
       title: lbl,
-      icon: L.icon({
+      icon: _L.icon({
         iconUrl: '@@INCLUDEIMAGE:images/marker-star.png@@',
         iconAnchor: [15,40],
         iconSize: [30,40]
@@ -1296,7 +1296,7 @@
     window.addPortalHighlighter('Bookmarked Portals', window.plugin.bookmarks.highlight);
 
     // Layer - Bookmarked portals
-    window.plugin.bookmarks.starLayerGroup = new L.LayerGroup();
+    window.plugin.bookmarks.starLayerGroup = new _L.LayerGroup();
     window.addLayerGroup('Bookmarked Portals', window.plugin.bookmarks.starLayerGroup, false);
     window.plugin.bookmarks.addAllStars();
     window.addHook('pluginBkmrksEdit', window.plugin.bookmarks.editStar);

--- a/plugins/broken/ap-list.user.js
+++ b/plugins/broken/ap-list.user.js
@@ -649,7 +649,7 @@ window.plugin.apList.setPortalLocationIndicator = function(guid) {
     map.removeLayer(plugin.apList.portalLocationIndicator);
   if(plugin.apList.animTimeout)
     clearTimeout(plugin.apList.animTimeout);
-  plugin.apList.portalLocationIndicator = L.circleMarker(latlng, property).addTo(map);
+  plugin.apList.portalLocationIndicator = _L.circleMarker(latlng, property).addTo(map);
   plugin.apList.animTimeout = setTimeout(plugin.apList.animPortalLocationIndicator,100);
 }
 

--- a/plugins/broken/scoreboard.user.js
+++ b/plugins/broken/scoreboard.user.js
@@ -292,8 +292,8 @@ window.plugin.scoreboard.display = function() {
 }
 
 window.plugin.scoreboard.portalDistance = function(portalAE6Location, portalBE6Location) {
-  portalA = new L.LatLng(portalAE6Location.latE6 / 1E6, portalAE6Location.lngE6 / 1E6);
-  portalB = new L.LatLng(portalBE6Location.latE6 / 1E6, portalBE6Location.lngE6 / 1E6);
+  portalA = new _L.LatLng(portalAE6Location.latE6 / 1E6, portalAE6Location.lngE6 / 1E6);
+  portalB = new _L.LatLng(portalBE6Location.latE6 / 1E6, portalBE6Location.lngE6 / 1E6);
   return (portalA.distanceTo(portalB));
 }
 

--- a/plugins/canvas-render.user.js
+++ b/plugins/canvas-render.user.js
@@ -37,7 +37,7 @@ window.plugin.canvasRendering = function() {};
 window.plugin.canvasRendering.setup  = function() {
 
   // nothing we can do here - other than check that canvas rendering was enabled
-  if (!L.Path.CANVAS) {
+  if (!_L.Path.CANVAS) {
     dialog({
       title:'Canvas Render Warning',
       text:'The Canvas Rendering plugin failed to enable canvas rendering in leaflet. This will occur if it initialises too late.\n'

--- a/plugins/cross_link.user.js
+++ b/plugins/cross_link.user.js
@@ -193,12 +193,12 @@ window.plugin.crossLinks.testLink = function (link) {
 
     for (var i in plugin.drawTools.drawnItems._layers) { // leaflet don't support breaking out of the loop
        var layer = plugin.drawTools.drawnItems._layers[i];
-       if (layer instanceof L.GeodesicPolygon) {
+       if (layer instanceof _L.GeodesicPolygon) {
            if (plugin.crossLinks.testPolyLine(layer, link,true)) {
                plugin.crossLinks.showLink(link);
                break;
            }
-        } else if (layer instanceof L.GeodesicPolyline) {
+        } else if (layer instanceof _L.GeodesicPolyline) {
             if (plugin.crossLinks.testPolyLine(layer, link)) {
                 plugin.crossLinks.showLink(link);
                 break;
@@ -210,7 +210,7 @@ window.plugin.crossLinks.testLink = function (link) {
 
 window.plugin.crossLinks.showLink = function(link) {
 
-    var poly = L.geodesicPolyline(link.getLatLngs(), {
+    var poly = _L.geodesicPolyline(link.getLatLngs(), {
        color: '#d22',
        opacity: 0.7,
        weight: 5,
@@ -238,11 +238,11 @@ window.plugin.crossLinks.testAllLinksAgainstLayer = function (layer) {
     $.each(window.links, function(guid, link) {
         if (!plugin.crossLinks.linkLayerGuids[link.options.guid])
         {
-            if (layer instanceof L.GeodesicPolygon) {
+            if (layer instanceof _L.GeodesicPolygon) {
                 if (plugin.crossLinks.testPolyLine(layer, link,true)) {
                     plugin.crossLinks.showLink(link);
                 }
-            } else if (layer instanceof L.GeodesicPolyline) {
+            } else if (layer instanceof _L.GeodesicPolyline) {
                 if (plugin.crossLinks.testPolyLine(layer, link)) {
                     plugin.crossLinks.showLink(link);
                 }
@@ -263,7 +263,7 @@ window.plugin.crossLinks.testForDeletedLinks = function () {
 }
 
 window.plugin.crossLinks.createLayer = function() {
-    window.plugin.crossLinks.linkLayer = new L.FeatureGroup();
+    window.plugin.crossLinks.linkLayer = new _L.FeatureGroup();
     window.plugin.crossLinks.linkLayerGuids={};
     window.addLayerGroup('Cross Links', window.plugin.crossLinks.linkLayer, true);
 

--- a/plugins/distance-to-portal.user.js
+++ b/plugins/distance-to-portal.user.js
@@ -124,10 +124,10 @@ window.plugin.distanceToPortal.setupPortalsList = function() {
 
 window.plugin.distanceToPortal.setup  = function() {
   // https://github.com/gregallensworth/Leaflet/
-  @@INCLUDERAW:external/LatLng_Bearings.js@@
+  (function (L) {@@INCLUDERAW:external/LatLng_Bearings.js@@})(_L);
 
   try {
-    window.plugin.distanceToPortal.currentLoc = L.latLng(JSON.parse(localStorage['plugin-distance-to-portal']));
+    window.plugin.distanceToPortal.currentLoc = _L.latLng(JSON.parse(localStorage['plugin-distance-to-portal']));
   } catch(e) {
     window.plugin.distanceToPortal.currentLoc = null;
   }

--- a/plugins/done-links.user.js
+++ b/plugins/done-links.user.js
@@ -71,12 +71,12 @@ window.plugin.doneLinks.testLink = function (link) {
 
     for (var i in plugin.drawTools.drawnItems._layers) { // leaflet don't support breaking out of the loop
        var layer = plugin.drawTools.drawnItems._layers[i];
-       if (layer instanceof L.GeodesicPolygon) {
+       if (layer instanceof _L.GeodesicPolygon) {
            if (plugin.doneLinks.testPolyLine(layer, link,true)) {
                plugin.doneLinks.showLink(link);
                break;
            }
-        } else if (layer instanceof L.GeodesicPolyline) {
+        } else if (layer instanceof _L.GeodesicPolyline) {
             if (plugin.doneLinks.testPolyLine(layer, link)) {
                 plugin.doneLinks.showLink(link);
                 break;
@@ -88,7 +88,7 @@ window.plugin.doneLinks.testLink = function (link) {
 
 window.plugin.doneLinks.showLink = function(link) {
 
-    var poly = L.geodesicPolyline(link.getLatLngs(), {
+    var poly = _L.geodesicPolyline(link.getLatLngs(), {
        color: COLORS[link.options.team],
        opacity: 0.8,
        weight: 6,
@@ -116,11 +116,11 @@ window.plugin.doneLinks.testAllLinksAgainstLayer = function (layer) {
     $.each(window.links, function(guid, link) {
         if (!plugin.doneLinks.linkLayerGuids[link.options.guid])
         {
-            if (layer instanceof L.GeodesicPolygon) {
+            if (layer instanceof _L.GeodesicPolygon) {
                 if (plugin.doneLinks.testPolyLine(layer, link,true)) {
                     plugin.doneLinks.showLink(link);
                 }
-            } else if (layer instanceof L.GeodesicPolyline) {
+            } else if (layer instanceof _L.GeodesicPolyline) {
                 if (plugin.doneLinks.testPolyLine(layer, link)) {
                     plugin.doneLinks.showLink(link);
                 }
@@ -141,7 +141,7 @@ window.plugin.doneLinks.testForDeletedLinks = function () {
 }
 
 window.plugin.doneLinks.createLayer = function() {
-    window.plugin.doneLinks.linkLayer = new L.FeatureGroup();
+    window.plugin.doneLinks.linkLayer = new _L.FeatureGroup();
     window.plugin.doneLinks.linkLayerGuids={};
     window.addLayerGroup('Done Links', window.plugin.doneLinks.linkLayer, true);
 

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -28,7 +28,7 @@ window.plugin.drawTools = function() {};
 
 window.plugin.drawTools.loadExternals = function() {
   try { console.log('Loading leaflet.draw JS now'); } catch(e) {}
-  @@INCLUDERAW:external/leaflet.draw.js@@
+  (function (L) {@@INCLUDERAW:external/leaflet.draw.js@@})(_L);
   @@INCLUDERAW:external/spectrum/spectrum.js@@
   try { console.log('done loading leaflet.draw JS'); } catch(e) {}
 
@@ -46,12 +46,12 @@ window.plugin.drawTools.getMarkerIcon = function(color) {
 
   var svgIcon = window.plugin.drawTools.markerTemplate.replace(/%COLOR%/g, color);
 
-  return L.divIcon({
-    iconSize: new L.Point(25, 41),
-    iconAnchor: new L.Point(12, 41),
+  return _L.divIcon({
+    iconSize: new _L.Point(25, 41),
+    iconAnchor: new _L.Point(12, 41),
     html: svgIcon,
     className: 'leaflet-iitc-custom-icon',
-    // L.divIcon does not use the option color, but we store it here to
+    // _L.divIcon does not use the option color, but we store it here to
     // be able to simply retrieve the color for serializing markers
     color: color
   });
@@ -71,13 +71,13 @@ window.plugin.drawTools.setOptions = function() {
     clickable: true
   };
 
-  window.plugin.drawTools.polygonOptions = L.extend({}, window.plugin.drawTools.lineOptions, {
+  window.plugin.drawTools.polygonOptions = _L.extend({}, window.plugin.drawTools.lineOptions, {
     fill: true,
     fillColor: null, // to use the same as 'color' for fill
     fillOpacity: 0.2
   });
 
-  window.plugin.drawTools.editOptions = L.extend({}, window.plugin.drawTools.polygonOptions, {
+  window.plugin.drawTools.editOptions = _L.extend({}, window.plugin.drawTools.polygonOptions, {
     dashArray: [10,10]
   });
   delete window.plugin.drawTools.editOptions.color;
@@ -107,7 +107,7 @@ window.plugin.drawTools.setDrawColor = function(color) {
 
 // renders the draw control buttons in the top left corner
 window.plugin.drawTools.addDrawControl = function() {
-  var drawControl = new L.Control.Draw({
+  var drawControl = new _L.Control.Draw({
     draw: {
       rectangle: false,
       polygon: {
@@ -144,7 +144,7 @@ window.plugin.drawTools.addDrawControl = function() {
 
       // Options for marker (icon, zIndexOffset) are not set via shapeOptions,
       // so we have merge them here!
-      marker: L.extend({}, window.plugin.drawTools.markerOptions, {
+      marker: _L.extend({}, window.plugin.drawTools.markerOptions, {
         title: 'Add a marker.\n\n'
           + 'Click on the button, then click on the map where\n'
           + 'you want the marker to appear.',
@@ -177,7 +177,7 @@ window.plugin.drawTools.addDrawControl = function() {
 
   window.plugin.drawTools.setAccessKeys();
   for (var toolbarId in drawControl._toolbars) {
-    if (drawControl._toolbars[toolbarId] instanceof L.Toolbar) {
+    if (drawControl._toolbars[toolbarId] instanceof _L.Toolbar) {
       drawControl._toolbars[toolbarId].on('enable', function() {
         setTimeout(window.plugin.drawTools.setAccessKeys, 10);
       });
@@ -232,7 +232,7 @@ window.plugin.drawTools.getSnapLatLng = function(unsnappedLatLng) {
 
   if(candidates.length === 0) return unsnappedLatLng;
   candidates = candidates.sort(function(a, b) { return a[0]-b[0]; });
-  return new L.LatLng(candidates[0][1].lat, candidates[0][1].lng);  //return a clone of the portal location
+  return new _L.LatLng(candidates[0][1].lat, candidates[0][1].lng);  //return a clone of the portal location
 }
 
 
@@ -241,20 +241,20 @@ window.plugin.drawTools.save = function() {
 
   window.plugin.drawTools.drawnItems.eachLayer( function(layer) {
     var item = {};
-    if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
+    if (layer instanceof _L.GeodesicCircle || layer instanceof _L.Circle) {
       item.type = 'circle';
       item.latLng = layer.getLatLng();
       item.radius = layer.getRadius();
       item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
+    } else if (layer instanceof _L.GeodesicPolygon || layer instanceof _L.Polygon) {
       item.type = 'polygon';
       item.latLngs = layer.getLatLngs();
       item.color = layer.options.color;
-    } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
+    } else if (layer instanceof _L.GeodesicPolyline || layer instanceof _L.Polyline) {
       item.type = 'polyline';
       item.latLngs = layer.getLatLngs();
       item.color = layer.options.color;
-    } else if (layer instanceof L.Marker) {
+    } else if (layer instanceof _L.Marker) {
       item.type = 'marker';
       item.latLng = layer.getLatLng();
       item.color = layer.options.icon.options.color;
@@ -292,18 +292,18 @@ window.plugin.drawTools.import = function(data) {
 
     switch(item.type) {
       case 'polyline':
-        layer = L.geodesicPolyline(item.latLngs, L.extend({},window.plugin.drawTools.lineOptions,extraOpt));
+        layer = _L.geodesicPolyline(item.latLngs, _L.extend({},window.plugin.drawTools.lineOptions,extraOpt));
         break;
       case 'polygon':
-        layer = L.geodesicPolygon(item.latLngs, L.extend({},window.plugin.drawTools.polygonOptions,extraOpt));
+        layer = _L.geodesicPolygon(item.latLngs, _L.extend({},window.plugin.drawTools.polygonOptions,extraOpt));
         break;
       case 'circle':
-        layer = L.geodesicCircle(item.latLng, item.radius, L.extend({},window.plugin.drawTools.polygonOptions,extraOpt));
+        layer = _L.geodesicCircle(item.latLng, item.radius, _L.extend({},window.plugin.drawTools.polygonOptions,extraOpt));
         break;
       case 'marker':
         var extraMarkerOpt = {};
         if (item.color) extraMarkerOpt.icon = window.plugin.drawTools.getMarkerIcon(item.color);
-        layer = L.marker(item.latLng, L.extend({},window.plugin.drawTools.markerOptions,extraMarkerOpt));
+        layer = _L.marker(item.latLng, _L.extend({},window.plugin.drawTools.markerOptions,extraMarkerOpt));
         window.registerMarkerForOMS(layer);
         break;
       default:
@@ -376,15 +376,15 @@ window.plugin.drawTools.optCopy = function() {
       var stockWarnings = {};
       var stockLinks = [];
       window.plugin.drawTools.drawnItems.eachLayer( function(layer) {
-        if (layer instanceof L.GeodesicCircle || layer instanceof L.Circle) {
+        if (layer instanceof _L.GeodesicCircle || layer instanceof _L.Circle) {
           stockWarnings.noCircle = true;
           return; //.eachLayer 'continue'
-        } else if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
+        } else if (layer instanceof _L.GeodesicPolygon || layer instanceof _L.Polygon) {
           stockWarnings.polyAsLine = true;
           // but we can export them
-        } else if (layer instanceof L.GeodesicPolyline || layer instanceof L.Polyline) {
+        } else if (layer instanceof _L.GeodesicPolyline || layer instanceof _L.Polyline) {
           // polylines are fine
-        } else if (layer instanceof L.Marker) {
+        } else if (layer instanceof _L.Marker) {
           stockWarnings.noMarker = true;
           return; //.eachLayer 'continue'
         } else {
@@ -398,7 +398,7 @@ window.plugin.drawTools.optCopy = function() {
           stockLinks.push([latLngs[i].lat,latLngs[i].lng,latLngs[i+1].lat,latLngs[i+1].lng]);
         }
         // for polygons, we also need a final link from last to first point
-        if (layer instanceof L.GeodesicPolygon || layer instanceof L.Polygon) {
+        if (layer instanceof _L.GeodesicPolygon || layer instanceof _L.Polygon) {
           stockLinks.push([latLngs[latLngs.length-1].lat,latLngs[latLngs.length-1].lng,latLngs[0].lat,latLngs[0].lng]);
         }
       });
@@ -459,7 +459,7 @@ window.plugin.drawTools.optPaste = function() {
           for (var j=0; j<floats.length; j++) {
             if (isNaN(floats[j])) throw("URL item had invalid number");
           }
-          var layer = L.geodesicPolyline([[floats[0],floats[1]],[floats[2],floats[3]]], window.plugin.drawTools.lineOptions);
+          var layer = _L.geodesicPolyline([[floats[0],floats[1]],[floats[2],floats[3]]], window.plugin.drawTools.lineOptions);
           newLines.push(layer);
         }
 
@@ -581,7 +581,7 @@ window.plugin.drawTools.snapToPortals = function() {
         testCount++;
         var newll = findClosestPortalLatLng(ll);
         if (!newll.equals(ll)) {
-          layer.setLatLng(new L.LatLng(newll.lat,newll.lng));
+          layer.setLatLng(new _L.LatLng(newll.lat,newll.lng));
           changedCount++;
         }
       }
@@ -593,7 +593,7 @@ window.plugin.drawTools.snapToPortals = function() {
           testCount++;
           var newll = findClosestPortalLatLng(lls[i]);
           if (!newll.equals(lls[i])) {
-            lls[i] = new L.LatLng(newll.lat,newll.lng);
+            lls[i] = new _L.LatLng(newll.lat,newll.lng);
             changedCount++;
             layerChanged = true;
           }
@@ -623,7 +623,7 @@ window.plugin.drawTools.boot = function() {
   window.plugin.drawTools.setOptions();
 
   //create a leaflet FeatureGroup to hold drawn items
-  window.plugin.drawTools.drawnItems = new L.FeatureGroup();
+  window.plugin.drawTools.drawnItems = new _L.FeatureGroup();
 
   //load any previously saved items
   plugin.drawTools.load();
@@ -658,7 +658,7 @@ window.plugin.drawTools.boot = function() {
     window.plugin.drawTools.drawnItems.addLayer(layer);
     window.plugin.drawTools.save();
 
-    if(layer instanceof L.Marker) {
+    if(layer instanceof _L.Marker) {
       window.registerMarkerForOMS(layer);
     }
 

--- a/plugins/experimental/marker-canvas-icon-data.user.js
+++ b/plugins/experimental/marker-canvas-icon-data.user.js
@@ -28,9 +28,9 @@ window.plugin.markerIconCanvasUrl.setup  = function() {
   window.createMarker = function(latlng, data) {
     var icon = createMarkerIcon(data);
 
-    var options = L.extend({}, data, { icon: icon });
+    var options = _L.extend({}, data, { icon: icon });
 
-    var marker = L.marker (latlng, options);
+    var marker = _L.marker (latlng, options);
     marker.bringToFront = function(){}; //TEMP - until the rest of IITC code is changed to take account of non-path markers
     return marker;
 
@@ -50,7 +50,7 @@ window.plugin.markerIconCanvasUrl.setup  = function() {
     var lvlWeight = Math.max(2, Math.floor(details.level) / 1.5) * scale;
     var lvlRadius = (details.team === window.TEAM_NONE ? 7 : Math.floor(details.level) + 4) * scale;
 
-    lvlRadius += (L.Browser.mobile ? PORTAL_RADIUS_ENLARGE_MOBILE*scale : 0);
+    lvlRadius += (_L.Browser.mobile ? PORTAL_RADIUS_ENLARGE_MOBILE*scale : 0);
 
     var fillColor = COLORS[details.team];
     var fillAlpha = 0.5;
@@ -96,7 +96,7 @@ window.plugin.markerIconCanvasUrl.setup  = function() {
 
     var dataurl = canvas.toDataURL();
 
-    return L.icon({
+    return _L.icon({
       iconUrl: dataurl,
       iconSize: [size,size],
       iconAnchor: [anchor,anchor]

--- a/plugins/experimental/marker-divicon-svg.user.js
+++ b/plugins/experimental/marker-divicon-svg.user.js
@@ -28,9 +28,9 @@ window.plugin.markerDivIconSvg.setup  = function() {
   window.createMarker = function(latlng, data) {
     var icon = createMarkerDivIcon(data);
 
-    var options = L.extend({}, data, { icon: icon });
+    var options = _L.extend({}, data, { icon: icon });
 
-    var marker = L.marker (latlng, options);
+    var marker = _L.marker (latlng, options);
     return marker;
 
   }
@@ -50,7 +50,7 @@ window.plugin.markerDivIconSvg.setup  = function() {
     var lvlWeight = Math.max(2, Math.floor(details.level) / 1.5) * scale;
     var lvlRadius = (details.team === window.TEAM_NONE ? 7 : Math.floor(details.level) + 4) * scale;
 
-    lvlRadius += (L.Browser.mobile ? PORTAL_RADIUS_ENLARGE_MOBILE*scale : 0);
+    lvlRadius += (_L.Browser.mobile ? PORTAL_RADIUS_ENLARGE_MOBILE*scale : 0);
 
     var size = Math.ceil(lvlRadius + lvlWeight/2)*2;
     var anchor = Math.floor(size/2);
@@ -59,7 +59,7 @@ window.plugin.markerDivIconSvg.setup  = function() {
             + '<circle cx="'+anchor+'" cy="'+anchor+'" r="'+lvlRadius+'" stroke="'+COLORS[details.team]+'" stroke-width="'+lvlWeight+'" fill="'+COLORS[details.team]+'" fill-opacity="0.5" />'
             + '</svg>';
 
-    return L.divIcon({
+    return _L.divIcon({
       iconSize: [size,size],
       iconAnchor: [anchor,anchor],
       className: 'portal-marker',

--- a/plugins/fix-googlemap-china-offset.user.js
+++ b/plugins/fix-googlemap-china-offset.user.js
@@ -133,7 +133,7 @@ var WGS84toGCJ02 = new WGS84transformer();
 
 /////////// begin overwrited L.Google /////////
 window.plugin.fixChinaOffset.L = {};
-window.plugin.fixChinaOffset.L.Google = {
+window.plugin.fixChinaOffset._L.Google = {
   
   _update: function(e) {
 
@@ -193,7 +193,7 @@ window.plugin.fixChinaOffset.overwrite = function(dest, src) {
 
 var setup = function() {
 
-  window.plugin.fixChinaOffset.overwrite(L.Google.prototype, window.plugin.fixChinaOffset.L.Google);
+  window.plugin.fixChinaOffset.overwrite(_L.Google.prototype, window.plugin.fixChinaOffset._L.Google);
 
 }
 

--- a/plugins/fly-links.user.js
+++ b/plugins/fly-links.user.js
@@ -67,7 +67,7 @@ window.plugin.flyLinks.updateLayer = function() {
     var alatlng = map.unproject(a, window.plugin.flyLinks.PROJECT_ZOOM);
     var blatlng = map.unproject(b, window.plugin.flyLinks.PROJECT_ZOOM);
 
-    var poly = L.polyline([alatlng, blatlng], style);
+    var poly = _L.polyline([alatlng, blatlng], style);
     poly.addTo(window.plugin.flyLinks.linksLayerGroup);
   }
   
@@ -76,7 +76,7 @@ window.plugin.flyLinks.updateLayer = function() {
     var blatlng = map.unproject(b, window.plugin.flyLinks.PROJECT_ZOOM);
     var clatlng = map.unproject(c, window.plugin.flyLinks.PROJECT_ZOOM);
     
-    var poly = L.polygon([alatlng, blatlng, clatlng], style);
+    var poly = _L.polygon([alatlng, blatlng, clatlng], style);
     poly.addTo(window.plugin.flyLinks.fieldsLayerGroup);
   }
   
@@ -281,8 +281,8 @@ window.plugin.flyLinks.Triangle = function(a, b, c, depth) {
 }
 
 window.plugin.flyLinks.setup = function() {
-  window.plugin.flyLinks.linksLayerGroup = new L.LayerGroup();
-  window.plugin.flyLinks.fieldsLayerGroup = new L.LayerGroup();
+  window.plugin.flyLinks.linksLayerGroup = new _L.LayerGroup();
+  window.plugin.flyLinks.fieldsLayerGroup = new _L.LayerGroup();
   
   window.addHook('mapDataRefreshEnd', function(e) {
     window.plugin.flyLinks.updateLayer();

--- a/plugins/guess-player-levels.user.js
+++ b/plugins/guess-player-levels.user.js
@@ -295,7 +295,7 @@ window.plugin.guessPlayerLevels.handleAttackData = function(nick, latlngs) {
   }
 
   // circle.range is useless, because it is calculated in degrees (simplified algorithm!)
-  var latlng = L.latLng(circle.y, circle.x);
+  var latlng = _L.latLng(circle.y, circle.x);
   var range = 0;
   for(var i=0; i<latlngs.length; i++) {
     var d = latlng.distanceTo([latlngs[i].y, latlngs[i].x]);
@@ -325,7 +325,7 @@ window.plugin.guessPlayerLevels.handleAttackData = function(nick, latlngs) {
     }
   }
 
-  //L.circle(latlng, range, {
+  //_L.circle(latlng, range, {
   //  weight:1,
   //  title: nick + ", " + range + "m"
   //}).addTo(map);

--- a/plugins/keys-on-map.user.js
+++ b/plugins/keys-on-map.user.js
@@ -69,8 +69,8 @@ window.plugin.keysOnMap.renderKey = function(guid,latLng) {
 
     var keyCount = plugin.keys.keys[guid];
     if (keyCount > 0) {
-      var key = L.marker(latLng, {
-        icon: L.divIcon({
+      var key = _L.marker(latLng, {
+        icon: _L.divIcon({
           className: 'plugin-keys-on-map-key',
           iconAnchor: [6,7],
           iconSize: [12,10],
@@ -115,7 +115,7 @@ window.plugin.keysOnMap.setupCSS = function() {
 }
 
 window.plugin.keysOnMap.setupLayer = function() {
-  window.plugin.keysOnMap.keyLayerGroup = new L.LayerGroup();
+  window.plugin.keysOnMap.keyLayerGroup = new _L.LayerGroup();
   window.addLayerGroup('Keys', window.plugin.keysOnMap.keyLayerGroup, false);
 }
 

--- a/plugins/layer-count.user.js
+++ b/plugins/layer-count.user.js
@@ -33,8 +33,8 @@ plugin.layerCount.onBtnClick = function(ev) {
 	if(btn.classList.contains("active")) {
 		if(window.plugin.drawTools !== undefined) {
 			window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-				if (layer instanceof L.GeodesicPolygon) {
-					L.DomUtil.addClass(layer._path, "leaflet-clickable");
+				if (layer instanceof _L.GeodesicPolygon) {
+					_L.DomUtil.addClass(layer._path, "leaflet-clickable");
 					layer._path.setAttribute("pointer-events", layer.options.pointerEventsBackup);
 					layer.options.pointerEvents = layer.options.pointerEventsBackup;
 					layer.options.clickable = true;
@@ -47,11 +47,11 @@ plugin.layerCount.onBtnClick = function(ev) {
 		console.log("inactive");
 		if(window.plugin.drawTools !== undefined) {
 			window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-				if (layer instanceof L.GeodesicPolygon) {
+				if (layer instanceof _L.GeodesicPolygon) {
 					layer.options.pointerEventsBackup = layer.options.pointerEvents;
 					layer.options.pointerEvents = null;
 					layer.options.clickable = false;
-					L.DomUtil.removeClass(layer._path, "leaflet-clickable");
+					_L.DomUtil.removeClass(layer._path, "leaflet-clickable");
 					layer._path.setAttribute("pointer-events", "none");
 				}
 			});
@@ -124,7 +124,7 @@ plugin.layerCount.calculate = function(ev) {
 	if (window.plugin.drawTools) {
 		for(var layerId in window.plugin.drawTools.drawnItems._layers) {
 			var field = window.plugin.drawTools.drawnItems._layers[layerId];
-			if(field instanceof L.GeodesicPolygon && plugin.layerCount.pnpoly(field._latlngs, point)) 
+			if(field instanceof _L.GeodesicPolygon && plugin.layerCount.pnpoly(field._latlngs, point)) 
 				layersDrawn++;
 		}
 	}

--- a/plugins/layer-farms-find.user.js
+++ b/plugins/layer-farms-find.user.js
@@ -172,7 +172,7 @@ window.plugin.farmFind.checkPortals = function(){
     
     
     
-    window.plugin.farmFind.drawnItems = new L.FeatureGroup();
+    window.plugin.farmFind.drawnItems = new _L.FeatureGroup();
     
     
     for (farm = 0; farm < farms.length; farm++)
@@ -245,10 +245,10 @@ window.plugin.farmFind.drawCircle = function(farm)
     //console.log(radius);
 	//((20 - map._zoom) * 1000) / map._zoom
     
-	var latlng = new L.LatLng(center.lat(), center.lng());
+	var latlng = new _L.LatLng(center.lat(), center.lng());
     //console.log("latlng: " + latlng);
     var optCircle = {color:'red',opacity:0.7,fill:true,fillColor:'red',fillOpacity:0.7,weight:15,clickable:true};
-    var circle = new L.Circle(latlng, radius, optCircle);
+    var circle = new _L.Circle(latlng, radius, optCircle);
     circle.bindPopup(popupMsg);
     
     
@@ -342,7 +342,7 @@ var setup =  function() {
     window.plugin.farmFind.Radius = 500;
     $('#toolbox').append(' <a onclick="window.plugin.farmFind.checkPortals()" id="findFarmClick" title="Check portals in view for L' + window.plugin.farmFind.minLevel + ' farms">L' + window.plugin.farmFind.minLevel + ' Farms</a>');
     possibleFarmPortals = [];
-    window.plugin.farmFind.levelLayerGroup = new L.LayerGroup();
+    window.plugin.farmFind.levelLayerGroup = new _L.LayerGroup();
 	$('body').append('<select onchange="window.plugin.farmFind.changeLevel()" id="farm_level_select"><option value=1>Farm level 1</option><option value=2>Farm level 2</option><option value=3>Farm level 3</option><option value=4>Farm level 4</option><option value=5>Farm level 5</option><option value=6>Farm level 6</option><option value=7>Farm level 7</option><option value=8>Farm level 8</option></select>');
     var myselect = document.getElementById("farm_level_select");
     myselect.options.selectedIndex = 6;

--- a/plugins/link-show-direction.user.js
+++ b/plugins/link-show-direction.user.js
@@ -90,7 +90,7 @@ window.plugin.linkShowDirection.addAllLinkStyles = function() {
 
   if(window.plugin.drawTools && localStorage['plugin-linkshowdirection-drawtools'] == "true") {
     window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-      if(layer instanceof L.GeodesicPolyline)
+      if(layer instanceof _L.GeodesicPolyline)
         window.plugin.linkShowDirection.addLinkStyle(layer);
     });
   }
@@ -104,7 +104,7 @@ window.plugin.linkShowDirection.removeDrawToolsStyle = function() {
   if(!window.plugin.drawTools) return;
 
   window.plugin.drawTools.drawnItems.eachLayer(function(layer) {
-    if(layer instanceof L.GeodesicPolyline)
+    if(layer instanceof _L.GeodesicPolyline)
       layer.setStyle({dashArray: null});
   });
 };
@@ -177,7 +177,7 @@ window.plugin.linkShowDirection.setup  = function() {
   }
 
   // only start the animation timer of the paths support SVG
-  if(L.Path.SVG) {
+  if(_L.Path.SVG) {
     window.plugin.linkShowDirection.animateLinks();
 
     // set up move start/end handlers to pause animations while moving

--- a/plugins/max-links.user.js
+++ b/plugins/max-links.user.js
@@ -44,8 +44,8 @@ window.plugin.maxLinks.errorMarker = null;
 
 window.plugin.maxLinks.addErrorMarker = function() {
   if (window.plugin.maxLinks.errorMarker == null) {
-    window.plugin.maxLinks.errorMarker = L.marker (window.map.getCenter(), {
-      icon: L.divIcon({
+    window.plugin.maxLinks.errorMarker = _L.marker (window.map.getCenter(), {
+      icon: _L.divIcon({
         className: 'max-links-error',
         iconSize: [300,30],
         html: 'Tidy Links: too many portals!'
@@ -123,7 +123,7 @@ window.plugin.maxLinks.updateLayer = function() {
       var alatlng = map.unproject (a, window.plugin.maxLinks.PROJECT_ZOOM);
       var blatlng = map.unproject (b, window.plugin.maxLinks.PROJECT_ZOOM);
 
-      var poly = L.polyline([alatlng, blatlng], window.plugin.maxLinks.STROKE_STYLE);
+      var poly = _L.polyline([alatlng, blatlng], window.plugin.maxLinks.STROKE_STYLE);
       poly.addTo(window.plugin.maxLinks.layer);
       drawnLinkCount++;
     }
@@ -141,7 +141,7 @@ window.plugin.maxLinks.setup = function() {
   @@INCLUDERAW:external/delaunay.js@@
   try { console.log('done loading delaunay JS'); } catch(e) {}
 
-  window.plugin.maxLinks.layer = L.layerGroup([]);
+  window.plugin.maxLinks.layer = _L.layerGroup([]);
 
   window.addHook('mapDataRefreshEnd', function(e) {
     window.plugin.maxLinks.updateLayer();

--- a/plugins/minimap.user.js
+++ b/plugins/minimap.user.js
@@ -28,9 +28,9 @@ window.plugin.miniMap = function() {};
 
 window.plugin.miniMap.setup  = function() {
 
-  try { console.log('Loading leaflet.draw JS now'); } catch(e) {}
-  @@INCLUDERAW:external/Control.MiniMap.js@@
-  try { console.log('done loading leaflet.draw JS'); } catch(e) {}
+  try { console.log('Loading Control.MiniMap JS now'); } catch(e) {}
+  (function (L) {@@INCLUDERAW:external/Control.MiniMap.js@@})(_L);
+  try { console.log('done loading Control.MiniMap JS'); } catch(e) {}
 
   // we can't use the same TileLayer as the main map uses - it causes issues.
   // stick with the Google tiles for now
@@ -40,7 +40,7 @@ window.plugin.miniMap.setup  = function() {
   var position = isSmartphone() ? 'bottomright' : 'bottomleft';
 
   setTimeout(function() {
-    new L.Control.MiniMap(new L.Google('ROADMAP',{maxZoom:21}), {toggleDisplay: true, position: position}).addTo(window.map);
+    new _L.Control.MiniMap(new _L.Google('ROADMAP',{maxZoom:21}), {toggleDisplay: true, position: position}).addTo(window.map);
   }, 0);
 
   $('head').append('<style>@@INCLUDESTRING:external/Control.MiniMap.css@@</style>');

--- a/plugins/missions.user.js
+++ b/plugins/missions.user.js
@@ -238,7 +238,7 @@ window.plugin.missions = {
 			return [waypoint.portal.latE6/1E6, waypoint.portal.lngE6/1E6];
 		});
 		
-		return L.latLngBounds(latlngs);
+		return _L.latLngBounds(latlngs);
 	},
 
 	loadMissionsInBounds: function(bounds, callback, errorcallback) {
@@ -379,7 +379,7 @@ window.plugin.missions = {
 			var len = cachedMission.waypoints.filter(function(waypoint) {
 				return !!waypoint.portal;
 			}).map(function(waypoint) {
-				return L.latLng(waypoint.portal.latE6/1E6, waypoint.portal.lngE6/1E6);
+				return _L.latLng(waypoint.portal.latE6/1E6, waypoint.portal.lngE6/1E6);
 			}).map(function(latlng1, i, latlngs) {
 				if(i == 0) return 0;
 				var latlng2 = latlngs[i - 1];
@@ -457,7 +457,7 @@ window.plugin.missions = {
 				return !!waypoint.portal;
 			})
 			.map(function(waypoint) {
-				var position = L.latLng(waypoint.portal.latE6/1E6, waypoint.portal.lngE6/1E6);
+				var position = _L.latLng(waypoint.portal.latE6/1E6, waypoint.portal.lngE6/1E6);
 				var distance = position.distanceTo(plugin.distanceToPortal.currentLoc);
 				return {
 					waypoint: waypoint,
@@ -756,7 +756,7 @@ window.plugin.missions = {
 			var ll = [waypoint.portal.latE6 / 1E6, waypoint.portal.lngE6 / 1E6];
 			latlngs.push(ll);
 			
-			var marker = L.circleMarker(ll, {
+			var marker = _L.circleMarker(ll, {
 					radius: radius,
 					weight: 3,
 					opacity: 1,
@@ -770,7 +770,7 @@ window.plugin.missions = {
 			markers.push(marker);
 		}, this);
 		
-		var line = L.geodesicPolyline(latlngs, {
+		var line = _L.geodesicPolyline(latlngs, {
 			color: this.MISSION_COLOR,
 			opacity: 1,
 			weight: 2,
@@ -813,8 +813,8 @@ window.plugin.missions = {
 				return;
 			}
 
-			this.markedStarterPortals[guid] = L.circleMarker(
-				L.latLng(portal.options.data.latE6 / 1E6, portal.options.data.lngE6 / 1E6), {
+			this.markedStarterPortals[guid] = _L.circleMarker(
+				_L.latLng(portal.options.data.latE6 / 1E6, portal.options.data.lngE6 / 1E6), {
 					radius: portal.options.radius + Math.ceil(portal.options.radius / 2),
 					weight: 3,
 					opacity: 1,
@@ -1071,8 +1071,8 @@ window.plugin.missions = {
 			};
 		}
 
-		this.missionStartLayer = new L.LayerGroup();
-		this.missionLayer = new L.LayerGroup();
+		this.missionStartLayer = new _L.LayerGroup();
+		this.missionLayer = new _L.LayerGroup();
 
 		window.addLayerGroup('Mission start portals', this.missionStartLayer, false);
 		window.addLayerGroup('Mission portals', this.missionLayer, true);

--- a/plugins/pan-control.user.js
+++ b/plugins/pan-control.user.js
@@ -28,21 +28,21 @@ window.plugin.panControl = function() {};
 
 window.plugin.panControl.setup  = function() {
   try { console.log('Loading Leaflet.Pancontrol JS now'); } catch(e) {}
-  @@INCLUDERAW:external/L.Control.Pan.js@@
+  (function (L) {@@INCLUDERAW:external/L.Control.Pan.js@@})(_L);
   try { console.log('done loading Leaflet.Pancontrol JS'); } catch(e) {}
 
   // prevent Pancontrol from being activated by default (e.g. in minimap)
-  L.Map.mergeOptions({
+  _L.Map.mergeOptions({
     panControl: false
   });
 
 
-  window.map.panControl = L.control.pan({panOffset: 350});
+  window.map.panControl = _L.control.pan({panOffset: 350});
   window.map.addControl(window.map.panControl);
 
   if(map.zoomControl._map) {  // Move above the zoom control
     window.map.removeControl(map.zoomControl);
-    window.map.zoomControl = L.control.zoom();
+    window.map.zoomControl = _L.control.zoom();
     window.map.addControl(window.map.zoomControl);
   }
 

--- a/plugins/player-tracker.user.js
+++ b/plugins/player-tracker.user.js
@@ -38,17 +38,17 @@ window.plugin.playerTracker.setup = function() {
   var iconResImage = '@@INCLUDEIMAGE:images/marker-blue.png@@';
   var iconResRetImage = '@@INCLUDEIMAGE:images/marker-blue-2x.png@@';
 
-  plugin.playerTracker.iconEnl = L.Icon.Default.extend({options: {
+  plugin.playerTracker.iconEnl = _L.Icon.Default.extend({options: {
     iconUrl: iconEnlImage,
     iconRetinaUrl: iconEnlRetImage
   }});
-  plugin.playerTracker.iconRes = L.Icon.Default.extend({options: {
+  plugin.playerTracker.iconRes = _L.Icon.Default.extend({options: {
     iconUrl: iconResImage,
     iconRetinaUrl: iconResRetImage
   }});
 
-  plugin.playerTracker.drawnTracesEnl = new L.LayerGroup();
-  plugin.playerTracker.drawnTracesRes = new L.LayerGroup();
+  plugin.playerTracker.drawnTracesEnl = new _L.LayerGroup();
+  plugin.playerTracker.drawnTracesRes = new _L.LayerGroup();
   // to avoid any favouritism, we'll put the player's own faction layer first
   if (PLAYER.team == 'RESISTANCE') {
     window.addLayerGroup('Player Tracker Resistance', plugin.playerTracker.drawnTracesRes, true);
@@ -65,7 +65,7 @@ window.plugin.playerTracker.setup = function() {
     }
   });
 
-  plugin.playerTracker.playerPopup = new L.Popup({offset: L.point([1,-34])});
+  plugin.playerTracker.playerPopup = new _L.Popup({offset: _L.point([1,-34])});
 
   addHook('publicChatDataAvailable', window.plugin.playerTracker.handleData);
 
@@ -259,7 +259,7 @@ window.plugin.playerTracker.getLatLngFromEvent = function(ev) {
     lngs += latlng[1];
   });
 
-  return L.latLng(lats / ev.latlngs.length, lngs / ev.latlngs.length);
+  return _L.latLng(lats / ev.latlngs.length, lngs / ev.latlngs.length);
 }
 
 window.plugin.playerTracker.ago = function(time, now) {
@@ -397,7 +397,7 @@ window.plugin.playerTracker.drawData = function() {
     var icon = playerData.team === 'RESISTANCE' ?  new plugin.playerTracker.iconRes() :  new plugin.playerTracker.iconEnl();
     // as per OverlappingMarkerSpiderfier docs, click events (popups, etc) must be handled via it rather than the standard
     // marker click events. so store the popup text in the options, then display it in the oms click handler
-    var m = L.marker(gllfe(last), {icon: icon, referenceToPortal: closestPortal, opacity: absOpacity, desc: popup[0], title: tooltip});
+    var m = _L.marker(gllfe(last), {icon: icon, referenceToPortal: closestPortal, opacity: absOpacity, desc: popup[0], title: tooltip});
     m.addEventListener('spiderfiedclick', plugin.playerTracker.onClickListener);
 
     // m.bindPopup(title);
@@ -431,7 +431,7 @@ window.plugin.playerTracker.drawData = function() {
     };
 
     $.each(polyLine,function(ind,poly) {
-      L.polyline(poly, opts).addTo(plugin.playerTracker.drawnTracesEnl);
+      _L.polyline(poly, opts).addTo(plugin.playerTracker.drawnTracesEnl);
     });
   });
   $.each(polyLineByAgeRes, function(i, polyLine) {
@@ -446,7 +446,7 @@ window.plugin.playerTracker.drawData = function() {
     };
 
     $.each(polyLine, function(ind,poly) {
-      L.polyline(poly, opts).addTo(plugin.playerTracker.drawnTracesRes);
+      _L.polyline(poly, opts).addTo(plugin.playerTracker.drawnTracesRes);
     });
   });
 }

--- a/plugins/portal-level-numbers.user.js
+++ b/plugins/portal-level-numbers.user.js
@@ -62,8 +62,8 @@ window.plugin.portalLevelNumbers.addLabel = function(guid,latLng) {
   // add portal level to layers
   var p = window.portals[guid];
   var levelNumber = p.options.level;
-  var level = L.marker(latLng, {
-    icon: L.divIcon({
+  var level = _L.marker(latLng, {
+    icon: _L.divIcon({
       className: 'plugin-portal-level-numbers',
       iconSize: [window.plugin.portalLevelNumbers.ICON_SIZE, window.plugin.portalLevelNumbers.ICON_SIZE],
       html: levelNumber
@@ -76,7 +76,7 @@ window.plugin.portalLevelNumbers.addLabel = function(guid,latLng) {
 
 window.plugin.portalLevelNumbers.updatePortalLabels = function() {
 
-  var SQUARE_SIZE = L.Browser.mobile ? (window.plugin.portalLevelNumbers.ICON_SIZE + 3) * window.plugin.portalLevelNumbers.MOBILE_SCALE
+  var SQUARE_SIZE = _L.Browser.mobile ? (window.plugin.portalLevelNumbers.ICON_SIZE + 3) * window.plugin.portalLevelNumbers.MOBILE_SCALE
                                      : (window.plugin.portalLevelNumbers.ICON_SIZE + 3);
 
   // as this is called every time layers are toggled, there's no point in doing it when the layer is off
@@ -99,7 +99,7 @@ window.plugin.portalLevelNumbers.updatePortalLabels = function() {
   for (var guid in portalPoints) {
     var point = portalPoints[guid];
 
-    var bucketId = L.point([Math.floor(point.x/(SQUARE_SIZE*2)),Math.floor(point.y/SQUARE_SIZE*2)]);
+    var bucketId = _L.point([Math.floor(point.x/(SQUARE_SIZE*2)),Math.floor(point.y/SQUARE_SIZE*2)]);
     // the guid is added to four buckets. this way, when testing for overlap we don't need to test
     // all 8 buckets surrounding the one around the particular portal, only the bucket it is in itself
     var bucketIds = [bucketId, bucketId.add([1,0]), bucketId.add([0,1]), bucketId.add([1,1])];
@@ -120,7 +120,7 @@ window.plugin.portalLevelNumbers.updatePortalLabels = function() {
       // overlap between two different portals text
       var southWest = point.subtract([SQUARE_SIZE, SQUARE_SIZE]);
       var northEast = point.add([SQUARE_SIZE, SQUARE_SIZE]);
-      var largeBounds = L.bounds(southWest, northEast);
+      var largeBounds = _L.bounds(southWest, northEast);
 
       for (var otherGuid in bucketGuids) {
         // do not check portals already marked as covered
@@ -172,7 +172,7 @@ var setup = function() {
 
   window.plugin.portalLevelNumbers.setupCSS();
 
-  window.plugin.portalLevelNumbers.levelLayerGroup = new L.LayerGroup();
+  window.plugin.portalLevelNumbers.levelLayerGroup = new _L.LayerGroup();
   window.addLayerGroup('Portal Levels', window.plugin.portalLevelNumbers.levelLayerGroup, true);
 
   window.addHook('requestFinished', function() { setTimeout(function(){window.plugin.portalLevelNumbers.delayedUpdatePortalLabels(3.0);},1); });

--- a/plugins/portal-names.user.js
+++ b/plugins/portal-names.user.js
@@ -62,8 +62,8 @@ window.plugin.portalNames.addLabel = function(guid, latLng) {
     var d = window.portals[guid].options.data;
     var portalName = d.title;
 
-    var label = L.marker(latLng, {
-      icon: L.divIcon({
+    var label = _L.marker(latLng, {
+      icon: _L.divIcon({
         className: 'plugin-portal-names',
         iconAnchor: [window.plugin.portalNames.NAME_WIDTH/2,0],
         iconSize: [window.plugin.portalNames.NAME_WIDTH,window.plugin.portalNames.NAME_HEIGHT],
@@ -104,7 +104,7 @@ window.plugin.portalNames.updatePortalLabels = function() {
   for (var guid in portalPoints) {
     var point = portalPoints[guid];
 
-    var bucketId = L.point([Math.floor(point.x/(window.plugin.portalNames.NAME_WIDTH*2)),Math.floor(point.y/window.plugin.portalNames.NAME_HEIGHT)]);
+    var bucketId = _L.point([Math.floor(point.x/(window.plugin.portalNames.NAME_WIDTH*2)),Math.floor(point.y/window.plugin.portalNames.NAME_HEIGHT)]);
     // the guid is added to four buckets. this way, when testing for overlap we don't need to test
     // all 8 buckets surrounding the one around the particular portal, only the bucket it is in itself
     var bucketIds = [bucketId, bucketId.add([1,0]), bucketId.add([0,1]), bucketId.add([1,1])];
@@ -123,7 +123,7 @@ window.plugin.portalNames.updatePortalLabels = function() {
       var point = portalPoints[guid];
       // the bounds used for testing are twice as wide as the portal name marker. this is so that there's no left/right
       // overlap between two different portals text
-      var largeBounds = L.bounds (
+      var largeBounds = _L.bounds (
                 point.subtract([window.plugin.portalNames.NAME_WIDTH,0]),
                 point.add([window.plugin.portalNames.NAME_WIDTH,window.plugin.portalNames.NAME_HEIGHT])
       );
@@ -176,7 +176,7 @@ window.plugin.portalNames.delayedUpdatePortalLabels = function(wait) {
 var setup = function() {
   window.plugin.portalNames.setupCSS();
 
-  window.plugin.portalNames.labelLayerGroup = new L.LayerGroup();
+  window.plugin.portalNames.labelLayerGroup = new _L.LayerGroup();
   window.addLayerGroup('Portal Names', window.plugin.portalNames.labelLayerGroup, true);
 
   window.addHook('requestFinished', function() { setTimeout(function(){window.plugin.portalNames.delayedUpdatePortalLabels(3.0);},1); });

--- a/plugins/regions.user.js
+++ b/plugins/regions.user.js
@@ -27,9 +27,9 @@
 window.plugin.regions = function() {};
 
 window.plugin.regions.setup  = function() {
-  @@INCLUDERAW:external/s2geometry.js@@
+  (function (L) {@@INCLUDERAW:external/s2geometry.js@@})(_L);
 
-  window.plugin.regions.regionLayer = L.layerGroup();
+  window.plugin.regions.regionLayer = _L.layerGroup();
 
   $("<style>")
     .prop("type", "text/css")
@@ -189,8 +189,8 @@ window.plugin.regions.getSearchResult = function(match) {
   var corners = cell.getCornerLatLngs();
 
   result.title = window.plugin.regions.regionName(cell);
-  result.layer = L.geodesicPolygon(corners, { fill: false, color: 'red', clickable: false });
-  result.bounds = L.latLngBounds(corners);
+  result.layer = _L.geodesicPolygon(corners, { fill: false, color: 'red', clickable: false });
+  result.bounds = _L.latLngBounds(corners);
 
   return result;
 }
@@ -213,7 +213,7 @@ window.plugin.regions.update = function() {
 
       // is it on the screen?
       var corners = cell.getCornerLatLngs();
-      var cellBounds = L.latLngBounds([corners[0],corners[1]]).extend(corners[2]).extend(corners[3]);
+      var cellBounds = _L.latLngBounds([corners[0],corners[1]]).extend(corners[2]).extend(corners[3]);
 
       if (cellBounds.intersects(bounds)) {
         // on screen - draw it
@@ -247,17 +247,17 @@ window.plugin.regions.update = function() {
   for (var i=0; i<latLngs.length-1; i++) {
     // the geodesic line code can't handle a line/polyline spanning more than (or close to?) 180 degrees, so we draw
     // each segment as a separate line
-    var poly1 = L.geodesicPolyline ( [latLngs[i], latLngs[i+1]], globalCellOptions );
+    var poly1 = _L.geodesicPolyline ( [latLngs[i], latLngs[i+1]], globalCellOptions );
     window.plugin.regions.regionLayer.addLayer(poly1);
 
     //southern mirror of the above
-    var poly2 = L.geodesicPolyline ( [[-latLngs[i][0],latLngs[i][1]], [-latLngs[i+1][0], latLngs[i+1][1]]], globalCellOptions );
+    var poly2 = _L.geodesicPolyline ( [[-latLngs[i][0],latLngs[i][1]], [-latLngs[i+1][0], latLngs[i+1][1]]], globalCellOptions );
     window.plugin.regions.regionLayer.addLayer(poly2);
   }
 
   // and the north-south lines. no need for geodesic here
   for (var i=-135; i<=135; i+=90) {
-    var poly = L.polyline ( [[35.264389682754654,i], [-35.264389682754654,i]], globalCellOptions );
+    var poly = _L.polyline ( [[35.264389682754654,i], [-35.264389682754654,i]], globalCellOptions );
     window.plugin.regions.regionLayer.addLayer(poly);
   }
 }
@@ -281,7 +281,7 @@ window.plugin.regions.drawCell = function(cell) {
   // the level 6 cells have noticible errors with non-geodesic lines - and the larger level 4 cells are worse
   // NOTE: we only draw two of the edges. as we draw all cells on screen, the other two edges will either be drawn
   // from the other cell, or be off screen so we don't care
-  var region = L.geodesicPolyline([corners[0],corners[1],corners[2]], {fill: false, color: color, opacity: 0.5, weight: 5, clickable: false });
+  var region = _L.geodesicPolyline([corners[0],corners[1],corners[2]], {fill: false, color: color, opacity: 0.5, weight: 5, clickable: false });
 
   window.plugin.regions.regionLayer.addLayer(region);
 
@@ -293,7 +293,7 @@ window.plugin.regions.drawCell = function(cell) {
       var newlat = Math.max(Math.min(center.lat, namebounds.getNorth()), namebounds.getSouth());
       var newlng = Math.max(Math.min(center.lng, namebounds.getEast()), namebounds.getWest());
 
-      var newpos = L.latLng(newlat,newlng);
+      var newpos = _L.latLng(newlat,newlng);
 
       // ensure the new position is still within the same cell
       var newposcell = S2.S2Cell.FromLatLng ( newpos, 6 );
@@ -304,8 +304,8 @@ window.plugin.regions.drawCell = function(cell) {
     }
   }
 
-  var marker = L.marker(center, {
-    icon: L.divIcon({
+  var marker = _L.marker(center, {
+    icon: _L.divIcon({
       className: 'plugin-regions-name',
       iconAnchor: [100,5],
       iconSize: [200,10],

--- a/plugins/scale-bar.user.js
+++ b/plugins/scale-bar.user.js
@@ -32,10 +32,10 @@ window.plugin.scaleBar.setup  = function() {
   // system already.
   if (window.isSmartphone()) {
       $('head').append('<style>.leaflet-control-scale { position: absolute; bottom: 15px; right: 0px; margin-bottom: 20px !important; } </style>');
-      window.map.addControl(new L.Control.Scale({position: 'bottomright', imperial: false, maxWidth: 100}));
+      window.map.addControl(new _L.Control.Scale({position: 'bottomright', imperial: false, maxWidth: 100}));
   } else {
       $('head').append('<style>.leaflet-control-scale { position: absolute; top: 2px; left: 40px; } </style>');
-      window.map.addControl(new L.Control.Scale({position: 'topleft', imperial: false, maxWidth: 200}));
+      window.map.addControl(new _L.Control.Scale({position: 'topleft', imperial: false, maxWidth: 200}));
   }
 };
 

--- a/plugins/show-linked-portals.user.js
+++ b/plugins/show-linked-portals.user.js
@@ -54,7 +54,7 @@ window.plugin.showLinkedPortal.portalDetail = function (data) {
     var lat = link[key + 'LatE6']/1E6;
     var lng = link[key + 'LngE6']/1E6;
 
-    var length = L.latLng(link.oLatE6/1E6, link.oLngE6/1E6).distanceTo([link.dLatE6/1E6, link.dLngE6/1E6]);
+    var length = _L.latLng(link.oLatE6/1E6, link.oLngE6/1E6).distanceTo([link.dLatE6/1E6, link.dLngE6/1E6]);
     var lengthFull = digits(Math.round(length)) + 'm';
     var lengthShort = length < 100000 ? lengthFull : digits(Math.round(length/1000)) + 'km'
 
@@ -122,7 +122,7 @@ plugin.showLinkedPortal.onLinkedPortalClick = function() {
 
   if(!guid) return; // overflow
 
-  var position = L.latLng(lat, lng);
+  var position = _L.latLng(lat, lng);
   if(!map.getBounds().contains(position)) map.setView(position);
   if(portals[guid])
     renderPortalDetails(guid);
@@ -139,15 +139,15 @@ plugin.showLinkedPortal.onLinkedPortalMouseOver = function() {
 
   if(!(lat && lng)) return; // overflow
 
-  var remote = L.latLng(lat, lng);
+  var remote = _L.latLng(lat, lng);
   var local = portals[selectedPortal].getLatLng();
 
-  plugin.showLinkedPortal.preview = L.layerGroup().addTo(map);
+  plugin.showLinkedPortal.preview = _L.layerGroup().addTo(map);
 
-  L.circleMarker(remote, plugin.showLinkedPortal.previewOptions)
+  _L.circleMarker(remote, plugin.showLinkedPortal.previewOptions)
     .addTo(plugin.showLinkedPortal.preview);
 
-  L.geodesicPolyline([local, remote], plugin.showLinkedPortal.previewOptions)
+  _L.geodesicPolyline([local, remote], plugin.showLinkedPortal.previewOptions)
     .addTo(plugin.showLinkedPortal.preview);
 };
 

--- a/plugins/zaprange.user.js
+++ b/plugins/zaprange.user.js
@@ -54,12 +54,12 @@
 
     if(faction !== TEAM_NONE) {
       var coo = d._latlng;
-      var latlng = new L.LatLng(coo.lat,coo.lng);
+      var latlng = new _L.LatLng(coo.lat,coo.lng);
       var portalLevel = d.options.level;
       var optCircle = {color:'red',opacity:0.7,fillColor:'red',fillOpacity:0.1,weight:1,clickable:false, dashArray: [10,6]};
       var range = (5*portalLevel)+35;
 
-      var circle = new L.Circle(latlng, range, optCircle);
+      var circle = new _L.Circle(latlng, range, optCircle);
 
       if(faction === TEAM_ENL) {
         circle.addTo(window.plugin.zaprange.zapCircleEnlHolderGroup);
@@ -96,12 +96,12 @@
 
   var setup =  function() {
     // this layer is added to the layer chooser, to be toggled on/off
-    window.plugin.zaprange.zapLayerEnlHolderGroup = new L.LayerGroup();
-    window.plugin.zaprange.zapLayerResHolderGroup = new L.LayerGroup();
+    window.plugin.zaprange.zapLayerEnlHolderGroup = new _L.LayerGroup();
+    window.plugin.zaprange.zapLayerResHolderGroup = new _L.LayerGroup();
 
     // this layer is added into the above layer, and removed from it when we zoom out too far
-    window.plugin.zaprange.zapCircleEnlHolderGroup = new L.LayerGroup();
-    window.plugin.zaprange.zapCircleResHolderGroup = new L.LayerGroup();
+    window.plugin.zaprange.zapCircleEnlHolderGroup = new _L.LayerGroup();
+    window.plugin.zaprange.zapCircleResHolderGroup = new _L.LayerGroup();
 
     window.plugin.zaprange.zapLayerEnlHolderGroup.addLayer(window.plugin.zaprange.zapCircleEnlHolderGroup);
     window.plugin.zaprange.zapLayerResHolderGroup.addLayer(window.plugin.zaprange.zapCircleResHolderGroup);

--- a/plugins/zoom-slider.user.js
+++ b/plugins/zoom-slider.user.js
@@ -28,18 +28,18 @@ window.plugin.zoomSlider = function() {};
 
 window.plugin.zoomSlider.setup  = function() {
   try { console.log('Loading Leaflet.zoomslider JS now'); } catch(e) {}
-  @@INCLUDERAW:external/L.Control.Zoomslider.js@@
+  (function (L) {@@INCLUDERAW:external/L.Control.Zoomslider.js@@})(_L);
   try { console.log('done loading Leaflet.zoomslider JS'); } catch(e) {}
 
   // prevent Zoomslider from being activated by default (e.g. in minimap)
-  L.Map.mergeOptions({
+  _L.Map.mergeOptions({
     zoomsliderControl: false
   });
 
   if(map.zoomControl._map) {
     window.map.removeControl(map.zoomControl);
   }
-  window.map.addControl(L.control.zoomslider());
+  window.map.addControl(_L.control.zoomslider());
 
   $('head').append('<style>@@INCLUDESTRING:external/L.Control.Zoomslider.css@@</style>');
 };


### PR DESCRIPTION
(prepared) fix for #964 "TypeError: L is not a constructor"

For 3rd-party plugins there is still a workaround ("L = _L" in boot.js) to give 3rd-party developer time to adjust their code. 
You have to remove this workaround to fix the #964.

As preparation developers should add something like:
"var _L = window._L || L; // TODO: remove on iitc update"

Note 1: no 'external' files were changed
Note 2: a bunch of plugins are affected. I wasn't able to fully-test them all.