### PR TITLE
Add .DS_Store to .gitignore for Mac developers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ localbuildsettings.py
 *.bak
 *.project
 .pydevproject
+.DS_Store
 
 ### JetBrains IDE Ignores ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm


### PR DESCRIPTION
Macs have a .DS_Store file, this causes git to ignore it, it should never be in a repo.