### PR TITLE
Fix crash when sharing on some devices

### DIFF
--- a/mobile/src/com/cradle/iitc_mobile/share/IntentGenerator.java
+++ b/mobile/src/com/cradle/iitc_mobile/share/IntentGenerator.java
@@ -39,7 +39,7 @@ public class IntentGenerator {
     public static String getTitle(final Intent intent) {
         String title = "";
         if (intent.hasExtra(EXTRA_FLAG_TITLE))
-            title = intent.getStringExtra(EXTRA_FLAG_TITLE);
+            title = intent.getCharSequenceExtra(EXTRA_FLAG_TITLE).toString();
 
         // Samsung WiFi Direct Sharing seems to not provide a title.
         // Not directly reproducible without having a Samsung device.


### PR DESCRIPTION
The [`ActivityInfo.loadLabel(PackageManager)`](https://developer.android.com/reference/android/content/pm/ComponentInfo.html#loadLabel(android.content.pm.PackageManager)) used at [IntentGenerator.java:100](https://github.com/iitc-project/ingress-intel-total-conversion/blob/0fabfb68943fc833153d89454220fa638a8b9fb6/mobile/src/com/cradle/iitc_mobile/share/IntentGenerator.java#L100) to create the `Intent`s for sharing returns a `CharSequence`. However, the current code tries to get it from the `Intent` as a `String` at [IntentGenerator.java:42](https://github.com/iitc-project/ingress-intel-total-conversion/blob/0fabfb68943fc833153d89454220fa638a8b9fb6/mobile/src/com/cradle/iitc_mobile/share/IntentGenerator.java#L42).

Certain devices (at least one LG G6) return a `SpannableString` instead of a `String`. This causes the `getStringExtra` method to fail and return `null`, which then causes a `NullPointerException` at [IntentComparator.java:81](https://github.com/iitc-project/ingress-intel-total-conversion/blob/0fabfb68943fc833153d89454220fa638a8b9fb6/mobile/src/com/cradle/iitc_mobile/share/IntentComparator.java#L819).

This can be fixed by properly getting the title as a `CharSequence` and turning it into a `String` using `toString()`.

See [this Pastebin](https://pastebin.com/raw/hz6bK6j8) for the stack trace.