### PR TITLE
Strip invalid characters from beginning and end of pasted strings

### DIFF
--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -476,7 +476,20 @@ window.plugin.drawTools.optPaste = function() {
 
 
       } else {
-        var data = JSON.parse(promptAction);
+		var data;
+        try{
+			data = JSON.parse(promptAction);
+        } catch(e) {
+			// invalid json, filter out any leading or trailing text and try again
+			var mutatedPromptAction = promptAction;
+			if(!mutatedPromptAction.match(new RegExp('^\\[\\{'))) {
+				mutatedPromptAction = mutatedPromptAction.slice(mutatedPromptAction.indexOf('[{'));
+			}
+			if(!mutatedPromptAction.match(new RegExp('\\}\\]$'))) {
+				mutatedPromptAction = mutatedPromptAction.slice(0, mutatedPromptAction.lastIndexOf('}]') + 2);
+			}
+			data = JSON.parse(mutatedPromptAction); // throws a new exception if we still didn't get good data, which is handled by the outer enclosure
+        }
         window.plugin.drawTools.drawnItems.clearLayers();
         window.plugin.drawTools.import(data);
         console.log('DRAWTOOLS: reset and imported drawn items');


### PR DESCRIPTION
Had a few people run into this lately, someone copies a drawtools polygon from iitc, the pastes it into a hangout along with descriptive text before or after. Someone else copies the whole text block and pastes it into drawtools, which fails to render because of the extra text.

This PR adds an extra try/catch that activates only if parsing the pasted JSON fails. It strips out anything before and after the first and last [{ }]. What's left is probably what the user actually wanted to paste, and is parsed as JSON.