### PR TITLE
 Fix .editorconfig for python indentation.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,8 +6,13 @@ root = true
 [*.{js,py}]
 charset = utf-8
 indent_style = space
-indent_size = 2
 trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 2
+
+[*.py]
+indent_size = 4
 
 # Following JS code style rules do not have EditorConfig support yet:
 # - Use identity operators (===) over equality operators (==).

--- a/build.py
+++ b/build.py
@@ -114,27 +114,27 @@ def loaderMD(var):
     # use different MD.dat's for python 2 vs 3 incase user switches versions, as they are not compatible
     db = shelve.open('build/MDv' + str(sys.version_info[0]) + '.dat')
     if 'files' in db:
-      files = db['files']
+        files = db['files']
     else:
-      files = {}
+        files = {}
     file = readfile(fn)
     filemd5 = hashlib.md5(file.encode('utf8')).hexdigest()
     # check if file has already been parsed by the github api
     if fn in files and filemd5 in files[fn]:
-      # use the stored copy if nothing has changed to avoid hitting the api more then the 60/hour when not signed in
-      db.close()
-      return files[fn][filemd5]
+        # use the stored copy if nothing has changed to avoid hitting the api more then the 60/hour when not signed in
+        db.close()
+        return files[fn][filemd5]
     else:
-      url = 'https://api.github.com/markdown'
-      payload = {'text': file, 'mode': 'markdown'}
-      headers = {'Content-Type': 'application/json'}
-      req = urllib2.Request(url, json.dumps(payload).encode('utf8'), headers)
-      md = urllib2.urlopen(req).read().decode('utf8').replace('\n', '\\n').replace('\'', '\\\'')
-      files[fn] = {}
-      files[fn][filemd5] = md
-      db['files'] = files
-      db.close()
-      return md
+        url = 'https://api.github.com/markdown'
+        payload = {'text': file, 'mode': 'markdown'}
+        headers = {'Content-Type': 'application/json'}
+        req = urllib2.Request(url, json.dumps(payload).encode('utf8'), headers)
+        md = urllib2.urlopen(req).read().decode('utf8').replace('\n', '\\n').replace('\'', '\\\'')
+        files[fn] = {}
+        files[fn][filemd5] = md
+        db['files'] = files
+        db.close()
+        return md
 
 def loaderImage(var):
     fn = var.group(1)


### PR DESCRIPTION
Python files are actually indented by four spaces.
This also fixes some mixed indentations in ```build.py```.