### PR TITLE
support new intel URL

### DIFF
--- a/mobile/AndroidManifest.xml
+++ b/mobile/AndroidManifest.xml
@@ -69,19 +69,19 @@
                     android:pathPrefix="/mission/"
                     android:scheme="http"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="https"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="http"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="https"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="http"/>
             </intent-filter>

--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
@@ -35,14 +35,8 @@ public class IITC_WebViewClient extends WebViewClient {
 
     public static final boolean isIntelUrl(String url) {
         return
-            url.startsWith("http://ingress.com/intel") ||
-            url.startsWith("https://ingress.com/intel") ||
-            url.startsWith("http://ingress.com/mission/") ||
-            url.startsWith("https://ingress.com/mission/") ||
-            url.startsWith("http://www.ingress.com/intel") ||
-            url.startsWith("https://www.ingress.com/intel") ||
-            url.startsWith("http://www.ingress.com/mission/") ||
-            url.startsWith("https://www.ingress.com/mission/");
+            url.matches("^https?://(?:.*\\.)?ingress\\.com/intel.*") ||
+            url.matches("^https?://(?:.*\\.)?ingress\\.com/mission.*");
     }
 
     private final IITC_Mobile mIitc;


### PR DESCRIPTION
Rather than add "intel.ingress.com" to the list use a RegEx like the desktop version does.