### PR TITLE
Add support for new intel URL + IITCM

### DIFF
--- a/code/boot.js
+++ b/code/boot.js
@@ -428,7 +428,7 @@ window.setupPlayerStat = function() {
     + '<h2 title="'+t+'">'+level+'&nbsp;'
     + '<div id="name">'
     + '<span class="'+cls+'">'+PLAYER.nickname+'</span>'
-    + '<a href="/_ah/logout?continue=https://www.google.com/accounts/Logout%3Fcontinue%3Dhttps://appengine.google.com/_ah/logout%253Fcontinue%253Dhttps://www.ingress.com/intel%26service%3Dah" id="signout">sign out</a>'
+    + '<a href="/_ah/logout?continue=https://www.google.com/accounts/Logout%3Fcontinue%3Dhttps://appengine.google.com/_ah/logout%253Fcontinue%253Dhttps://intel.ingress.com/intel%26service%3Dah" id="signout">sign out</a>'
     + '</div>'
     + '<div id="stats">'
     + '<sup>XM: '+xmRatio+'%</sup>'

--- a/mobile/AndroidManifest.xml
+++ b/mobile/AndroidManifest.xml
@@ -53,19 +53,19 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data
-                    android:host="intel.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="https"/>
                 <data
-                    android:host="intel.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="http"/>
                 <data
-                    android:host="intel.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="https"/>
                 <data
-                    android:host="intel.ingress.com"
+                    android:host="*.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="http"/>
             </intent-filter>

--- a/mobile/AndroidManifest.xml
+++ b/mobile/AndroidManifest.xml
@@ -53,35 +53,19 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
 
                 <data
-                    android:host="ingress.com"
+                    android:host="intel.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="https"/>
                 <data
-                    android:host="ingress.com"
-                    android:pathPrefix="/intel"
-                    android:scheme="http"/>
-                <data
-                    android:host="ingress.com"
-                    android:pathPrefix="/mission/"
-                    android:scheme="https"/>
-                <data
-                    android:host="ingress.com"
-                    android:pathPrefix="/mission/"
-                    android:scheme="http"/>
-                <data
-                    android:host="www.ingress.com"
-                    android:pathPrefix="/intel"
-                    android:scheme="https"/>
-                <data
-                    android:host="www.ingress.com"
+                    android:host="intel.ingress.com"
                     android:pathPrefix="/intel"
                     android:scheme="http"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="intel.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="https"/>
                 <data
-                    android:host="www.ingress.com"
+                    android:host="intel.ingress.com"
                     android:pathPrefix="/mission/"
                     android:scheme="http"/>
             </intent-filter>

--- a/mobile/src/com/cradle/iitc_mobile/IITC_Mobile.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_Mobile.java
@@ -63,7 +63,7 @@ import java.util.regex.Pattern;
 
 public class IITC_Mobile extends Activity
         implements OnSharedPreferenceChangeListener, NfcAdapter.CreateNdefMessageCallback, OnItemLongClickListener {
-    private static final String mIntelUrl = "https://www.ingress.com/intel";
+    private static final String mIntelUrl = "https://intel.ingress.com/intel";
 
     private SharedPreferences mSharedPrefs;
     private IITC_FileManager mFileManager;

--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
@@ -35,14 +35,14 @@ public class IITC_WebViewClient extends WebViewClient {
 
     public static final boolean isIntelUrl(String url) {
         return
-            url.startsWith("http://ingress.com/intel") ||
-            url.startsWith("https://ingress.com/intel") ||
-            url.startsWith("http://ingress.com/mission/") ||
-            url.startsWith("https://ingress.com/mission/") ||
-            url.startsWith("http://www.ingress.com/intel") ||
-            url.startsWith("https://www.ingress.com/intel") ||
-            url.startsWith("http://www.ingress.com/mission/") ||
-            url.startsWith("https://www.ingress.com/mission/");
+            url.startsWith("https://intel.ingress.com") ||
+            url.startsWith("https://intel.ingress.com/intel") ||
+            url.startsWith("https://intel.ingress.com/mission/") ||
+
+            // legacy non-https
+            url.startsWith("http://intel.ingress.com") ||
+            url.startsWith("http://intel.ingress.com/intel") ||
+            url.startsWith("http://intel.ingress.com/mission/");
     }
 
     private final IITC_Mobile mIitc;

--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
@@ -36,8 +36,8 @@ public class IITC_WebViewClient extends WebViewClient {
     public static final boolean isIntelUrl(String url) {
         return
             url.startsWith("https://intel.ingress.com") ||
-            url.matches("^https?://(?:.*\\.)?ingress\\.com/intel.*") ||
-            url.matches("^https?://(?:.*\\.)?ingress\\.com/mission.*");
+            url.matches("^https?://(?:intel\\.)?ingress\\.com/intel.*") ||
+            url.matches("^https?://(?:intel\\.)?ingress\\.com/mission.*");
     }
 
     private final IITC_Mobile mIitc;

--- a/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
+++ b/mobile/src/com/cradle/iitc_mobile/IITC_WebViewClient.java
@@ -36,13 +36,8 @@ public class IITC_WebViewClient extends WebViewClient {
     public static final boolean isIntelUrl(String url) {
         return
             url.startsWith("https://intel.ingress.com") ||
-            url.startsWith("https://intel.ingress.com/intel") ||
-            url.startsWith("https://intel.ingress.com/mission/") ||
-
-            // legacy non-https
-            url.startsWith("http://intel.ingress.com") ||
-            url.startsWith("http://intel.ingress.com/intel") ||
-            url.startsWith("http://intel.ingress.com/mission/");
+            url.matches("^https?://(?:.*\\.)?ingress\\.com/intel.*") ||
+            url.matches("^https?://(?:.*\\.)?ingress\\.com/mission.*");
     }
 
     private final IITC_Mobile mIitc;

--- a/mobile/src/com/cradle/iitc_mobile/share/ShareActivity.java
+++ b/mobile/src/com/cradle/iitc_mobile/share/ShareActivity.java
@@ -69,7 +69,7 @@ public class ShareActivity extends FragmentActivity implements ActionBar.TabList
 
     private String getIntelUrl(final String ll, final int zoom, final boolean isPortal) {
         final String scheme = mSharedPrefs.getBoolean("pref_force_https", true) ? "https" : "http";
-        String url = scheme + "://www.ingress.com/intel?ll=" + ll + "&z=" + zoom;
+        String url = scheme + "://intel.ingress.com/intel?ll=" + ll + "&z=" + zoom;
         if (isPortal) {
             url += "&pll=" + ll;
         }

--- a/plugins/draw-tools.user.js
+++ b/plugins/draw-tools.user.js
@@ -403,7 +403,7 @@ window.plugin.drawTools.optCopy = function() {
           stockLinks.push([latLngs[latLngs.length-1].lat,latLngs[latLngs.length-1].lng,latLngs[0].lat,latLngs[0].lng]);
         }
       });
-      var stockUrl = 'https://www.ingress.com/intel?ll='+map.getCenter().lat+','+map.getCenter().lng+'&z='+map.getZoom()+'&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
+      var stockUrl = 'https://intel.ingress.com/intel?ll='+map.getCenter().lat+','+map.getCenter().lng+'&z='+map.getZoom()+'&pls='+stockLinks.map(function(link){return link.join(',');}).join('_');
       var stockWarnTexts = [];
       if (stockWarnings.polyAsLine) stockWarnTexts.push('Note: polygons are exported as lines');
       if (stockLinks.length>40) stockWarnTexts.push('Warning: Stock intel may not work with more than 40 line segments - there are '+stockLinks.length);

--- a/website/page/about.php
+++ b/website/page/about.php
@@ -2,7 +2,7 @@
 
 <p>
 Ingress Intel Total Conversion (IITC) is a browser modification to the <a href="http://www.ingress.com/">Ingress</a>
-<a href="http://www.ingress.com/intel">intel map</a>.
+<a href="http://intel.ingress.com/intel">intel map</a>.
 </p>
 
 <p>


### PR DESCRIPTION
So 

 * `www` intel map seems dead. So killed that cruff
 * `intel.ingress.com` works, but far too many changes for IITC to support that, so keeping the redundant `intel.ingress.com/intel`
 * I want to kill off legacy - `http`, but redirects still work so left that
 * Updated draw-tools and anything I found with reference to "www.ingress.com/intel"
 * I tested a build of IITCM and it worked. I can only build test builds, but it worked.
* fixes #1276 

Took a bit to build mobile, its using Android 4.4.2, API19 and the Ant build system isn't even in new build tools so had to downgrade and build it. If you need to downgrade your build tools, check this - https://stackoverflow.com/a/42921645/455008

Based off the work of @EvoldicA & @terencehonles 