### PR TITLE
layer-farms-find: limit farm portals to desired min level

### DIFF
--- a/plugins/layer-farms-find.user.js
+++ b/plugins/layer-farms-find.user.js
@@ -78,7 +78,7 @@ window.plugin.farmFind.checkPortals = function(){
     //console.log(window.portals.length);
 	$.each(window.portals, function(i, portal) {
         
-		if (window.plugin.farmFind.getNearbyPortalCount(portal) > window.plugin.farmFind.minNearby)
+		if (window.plugin.farmFind.getNearbyPortalCount(portal) > window.plugin.farmFind.minNearby && portal.options.level >= window.plugin.farmFind.minLevel)
         {
          	//console.log("Farm identified");
             possibleFarmPortals.push(portal);


### PR DESCRIPTION
Portals listed as possible farm portals should be at least the minlevel. This fixes a a crazy corner case I came across:
4 farm-level portals in a cluster, two level 1 portals about 400m east, then another farm-level portal 400m east of the level 1 portals.
The current algorithm thinks the 2 level 1 portals are a farm (since 5 farm-level portals are within 500m radius of the level 1 portals) and draws a circle only around the two level 1 portals.

Alternatively, this check can be placed in the "getNearbyPortalCount" function.